### PR TITLE
Feature/unlimited `FileLogger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ If this directory does not currently exist, it will be created.
 This sets a prefix that will be added to log file names.
 
 `WithMaxLogPerFile(int maxLogs)`
-This limits how many lines are logged to the file before a new log file is created.
+This limits how many lines are logged to the file before a new log file is created. If you pass this method a value of 0 or lower, it will not cap the number of logs in a file.
 
 ### ILogger
 
@@ -323,6 +323,8 @@ On construction, you can set:
 * The directory path that is used for log files 
 * The maximum number of lines logged per file
 * A prefix for the log files name
+
+NB: Setting the maximum number of lines logged per file at 0 or less will indicate that there is no limit to the [`FileLogger`](#FileLogger) and thus will only ever use one file.
 
 ---
 

--- a/TinYard/Extensions/Logging/Impl/Loggers/FileLogger.cs
+++ b/TinYard/Extensions/Logging/Impl/Loggers/FileLogger.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using TinYard.Extensions.Logging.API.Interfaces;
 
 namespace TinYard.Extensions.Logging.Impl.Loggers
@@ -10,6 +10,7 @@ namespace TinYard.Extensions.Logging.Impl.Loggers
         private string _fileDestination;
         private string _fileNamePrefix;
         private int _maxLogPerFile;
+        private bool _hasMaxLogCount = true;
 
         private string _lastLogFilePath;
 
@@ -22,6 +23,7 @@ namespace TinYard.Extensions.Logging.Impl.Loggers
             _fileDestination = fileDestination;
             _fileNamePrefix = fileNamePrefix;
             _maxLogPerFile = maxLogPerFile;
+            _hasMaxLogCount = _maxLogPerFile > 0;
 
             InitialiseLastLogFilePath();
         }
@@ -50,7 +52,8 @@ namespace TinYard.Extensions.Logging.Impl.Loggers
         private string GetLogFilePath()
         {
             //If it doesn't exist, this path is valid
-            if(File.Exists(_lastLogFilePath))
+            //And if we've got a max log per file count
+            if(File.Exists(_lastLogFilePath) && _hasMaxLogCount)
             {
                 //Check if we've reached max logs for this file, if so - create a new one
                 if(File.ReadAllLines(_lastLogFilePath).Length >= _maxLogPerFile)


### PR DESCRIPTION
Resolves #27 

Added capabilities to the `FileLogger` that allows for an unlimited number of lines of logs per file.

This is achieved by passing a value of 0 or less in the construction of the `FileLogger`, as it will set a boolean flag indicating not to create a new file.