### PR TITLE
Feature / IFileLogger

### DIFF
--- a/TinYard/Extensions/Logging/API/Interfaces/IFileLogger.cs
+++ b/TinYard/Extensions/Logging/API/Interfaces/IFileLogger.cs
@@ -1,0 +1,7 @@
+﻿namespace TinYard.Extensions.Logging.API.Interfaces
+{
+    public interface IFileLogger : ILogger
+    {
+        string LastLogFilePath { get; }
+    }
+}

--- a/TinYard/Extensions/Logging/API/Interfaces/ILogger.cs
+++ b/TinYard/Extensions/Logging/API/Interfaces/ILogger.cs
@@ -2,8 +2,6 @@
 {
     public interface ILogger
     {
-        string LastLogFilePath { get; }
-
         void Log(string message);
         void LogWarning(string message);
         void LogError(string message);

--- a/TinYard/Extensions/Logging/Impl/Loggers/FileLogger.cs
+++ b/TinYard/Extensions/Logging/Impl/Loggers/FileLogger.cs
@@ -3,7 +3,7 @@ using TinYard.Extensions.Logging.API.Interfaces;
 
 namespace TinYard.Extensions.Logging.Impl.Loggers
 {
-    public class FileLogger : ILogger
+    public class FileLogger : IFileLogger
     {
         public string LastLogFilePath => _lastLogFilePath;
 


### PR DESCRIPTION
Added IFileLogger and implemented onto FileLogger

Removed `string LastLogFilePath { get; }` from `ILogger` and moved into `IFileLogger`.

Resolves #30 