### PR TITLE
Feature/Mediator Map Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ This Extension is dependant on:
 
 ### About the Extension
 
+This extension aims to provide a place to `Map` [`Mediator`](#IMediator)'s and [`IView`](#IView)'s together via the [`MediatorMapper`](#MediatorMapper).
+
+This `Mapper` will build the correct [`IMediator`](#IMediator) when the associated [`IView`](#IView) type has been registered to the [`ViewRegister`](#ViewRegister), and attach them together so that a [`IView`](#IView) can dispatch to everything else connected to the [`IContext`](#IContext).
+
 The [Mediator Map Extension](#Mediator-Map-Extension) provides:
 
 * The [`IMediator`](#IMediator) interface and base impl, [`Mediator`](#Mediator).

--- a/README.md
+++ b/README.md
@@ -180,15 +180,17 @@ The `ToValue<T>(bool autoInitialize = false)` function can instantiate a value o
 
 `MappingObject` provides a super-simple implementation of [`IMappingObject`](#IMappingObject) that is used by [`ValueMapper`](#ValueMapper). 
 
-`MappingObject` has a reference to the `IMapper` that creates it. This is so that it can use the Factory that the `IMapper` has to build an object when `ToValue<T>(bool)` is called on the `MappingObject`.
+`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when `ToValue<T>(bool)` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value.
 
 ### IInjector
 
-An `IInjector` should provide an easy-to-use `Inject` method.
+An `IInjector` should provide two easy-to-use `Inject` methods.
 
-This `Inject` method should provide the object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
+One `Inject` method should provide an object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
 
-How it does so and how it gets the correct value is up to the implementation.
+The other `Inject` method should have `target` and `value` objects passed as arguments. The `target` object should be injected into, specifically looking to provide it with the `value` object if possible.
+ 
+All [`IInjector`](#IInjector)'s should also have an internal collection of values that can be injected into any class when the first `Inject` method is called upon it. This collection should be added to / provided to the [`IInjector`](#IInjector) via the `AddInjectable` method. 
 
 #### TinYardInjector
 
@@ -196,7 +198,7 @@ How it does so and how it gets the correct value is up to the implementation.
 
 `TinYardInjector` requires an [`IContext`](#IContext) object to be passed to it when constructed.
 
-`TinYardInjector` provides the 'injected' value of a Field by finding a [`Mapping`](#IMappingObject) of the Field via the [`IContext`](#IContext) provided in construction and the [`IMapper`](#IMapper) that it has.
+`TinYardInjector` provides the 'injected' value of a Field by finding a [`Mapping`](#IMappingObject) of the Field via the [`IContext`](#IContext) provided in construction and the [`IMapper`](#IMapper) that it has, alongside its internal collection that can be added to via the `AddInjectable` method.
 
 #### Inject Attribute
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ The job of [`ViewRegister`](#ViewRegister) is to provide a place where all [`Vie
 
 ## Mediator Map Extension
 
+### Dependencies
+
+This Extension is dependant on:
+
+* [Event System Extension](#Event-System-Extension)
+
 ### About the Extension
 
 The [Mediator Map Extension](#Mediator-Map-Extension) provides:

--- a/README.md
+++ b/README.md
@@ -400,9 +400,17 @@ Currently, there are no configurations for the Extension.
 
 ### IMediator
 
+A [`Mediator`](#IMediator) provides the ability for each [`View`](#View) to have a [`dispatcher`](#IDispatcher) and ensure the [`View`](#View) can send event's out, and receive them too.
+
 ### Mediator
 
+This is the base implementation of [`IMediator`](#IMediator). 
+
 ### MediatorMapper
+
+Every View that gets registered needs to have an [`IMediator`](#IMediator). The [`MediatorMapper`](#MediatorMapper) helps ensure that each [`View`](#View) has a [`Mediator`](#Mediator) attached and being its [`dispatcher`](#IDispatcher).
+
+By 'mapping' a [`View`](#View) to a [`Mediator`](#Mediator), it guarantees that the [`Mediator`](#Mediator) will be created when the [`View`](#View) is registered - The [`MediatorMapper`](#MediatorMapper) uses a Factory to create the associated [`Mediator`](#Mediator) (but this can only happen if you 'map' one!).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -390,13 +390,16 @@ The job of [`ViewRegister`](#ViewRegister) is to provide a place where all [`Vie
 This Extension is dependant on:
 
 * [Event System Extension](#Event-System-Extension)
+* [View Controller Extension](#View-Controller-Extension)
 
 ### About the Extension
 
 The [Mediator Map Extension](#Mediator-Map-Extension) provides:
 
-* The base impl of [`IMediator`](#IMediator), [`Mediator`](#Mediator)
-* The [`MediatorMapper`](#MediatorMapper)
+* The [`IMediator`](#IMediator) interface and base impl, [`Mediator`](#Mediator).
+* The [`IMediatorMapper`](#IMediatorMapper) interface and base impl, [`MediatorMapper`](#MediatorMapper).
+* The [`IMediatorFactory`](#IMediatorFactory) interface and its base impl, [`MediatorFactory`](#MediatorFactory).
+* [`IMediatorMappingObject`](#IMediatorMappingObject) interface and impl, [`MediatorMappingObject`](#MediatorMappingObject).
 
 #### Extension and Configurations
 
@@ -406,17 +409,68 @@ Currently, there are no configurations for the Extension.
 
 ### IMediator
 
-A [`Mediator`](#IMediator) provides the ability for each [`View`](#View) to have a [`dispatcher`](#IDispatcher) and ensure the [`View`](#View) can send event's out, and receive them too.
+A [`Mediator`](#IMediator) provides the ability for each [`View`](#View) to send and receive events from every [`IEventDispatcher`](#IEventDispatcher) linked to the [`IContext`](#IContext).
+
+All implementations of this interface should provide a default constructor, to ensure they can be built by a [`IMediatorFactory`](#IMediatorFactory).
 
 ### Mediator
 
-This is the base implementation of [`IMediator`](#IMediator). 
+This is the base, abstract implementation of [`IMediator`](#IMediator). 
+
+The [`Mediator`](#Mediator) has the main mapped [`IEventDispatcher`](#IEventDispatcher) injected, and also has reference to the [`IView`](#IView) that it is listening to. 
+
+When the related [`IView`](#IView) property, known as ViewComponent, is set the [`Mediator`](#Mediator) will use reflection to fetch the [View's](#IView) [`IEventDispatcher`](#IEventDispatcher) so that it can hook into it and add listeners when required.
+
+The base [`Mediator`](#Mediator) class provides methods to add listeners to the [`IView`](#IView), as well as to the [`IContext`](#IContext)'s mapped [`IEventDispatcher`](#IEventDispatcher).
+
+##### Configure
+When creating your own [`Mediator`](#Mediator), you will have to provide a `Configure` method implementation. This is where you should add any listeners, as you will not have a reference to your [`IView`](#IView) in the constructor but this method should be called when a [`IView`](#IView) is provided.
+
+##### Attached View
+
+When creating your own [`Mediator`](#Mediator), you'll want to have a specific [`IView`](#IView) referenced as a field. To get this [`IView`](#IView), simply attach the [`Inject`](#Inject) attribute.
+
+### IMediatorMapper
+
+An [`IMediatorMapper`](#IMediatorMapper) provides a place to `Map` a [`IMediator`](#IMediator) to a respective object. The base implementation of this is the [`MediatorMapper`](#MediatorMapper).
+
+An [`IMediatorMapper`](#IMediatorMapper) should also have an [`IMediatorFactory`](#IMediatorFactory) associated with it that can create a [`IMediator`](#IMediator) for you.
 
 ### MediatorMapper
 
-Every View that gets registered needs to have an [`IMediator`](#IMediator). The [`MediatorMapper`](#MediatorMapper) helps ensure that each [`View`](#View) has a [`Mediator`](#Mediator) attached and being its [`dispatcher`](#IDispatcher).
+Every View that gets registered needs to have an [`IMediator`](#IMediator) to be heard outside of itself. The [`MediatorMapper`](#MediatorMapper) helps ensure that each [`View`](#View) has a [`Mediator`](#Mediator) attached and being its [`dispatcher`](#IDispatcher).
 
 By 'mapping' a [`View`](#View) to a [`Mediator`](#Mediator), it guarantees that the [`Mediator`](#Mediator) will be created when the [`View`](#View) is registered - The [`MediatorMapper`](#MediatorMapper) uses a Factory to create the associated [`Mediator`](#Mediator) (but this can only happen if you 'map' one!).
+
+Once the [`Mediator`](#Mediator) is created, it will be injected into by the [`Context`](#Context)'s [`IInjector`](#IInjector), as well as the [`View`](#View) value set.
+
+### IMediatorMappingObject
+
+An [`IMediatorMappingObject`](#IMediatorMappingObject) is similar to a [`IMappingObject`](#IMappingObject), but not the same.
+
+[`IMediatorMappingObject`](#IMediatorMappingObject) is built purposefully for [`IView`](#IView)'s and [`IMediator`](#IMediator)'s.
+
+The base implementation of [`IMediatorMappingObject`](#IMediatorMappingObject) is an [`MediatorMappingObject`](#MediatorMappingObject).
+
+### MediatorMappingObject
+
+The [`MediatorMappingObject`](#MediatorMappingObject) is the base implementation of [`IMediatorMappingObject`](#IMediatorMappingObject).
+
+As there is similarity to the [`IMappingObject`](#IMappingObject) class, one is used internally to do most of the work.
+
+[`MediatorMappingObject`](#MediatorMappingObject) simply provides different names to the [`IMappingObject`](#IMappingObject) methods, fields, and properties - As well as `Type` restrictions.
+
+### IMediatorFactory
+
+The [`IMediatorFactory`](#IMediatorFactory) interface extends upon the [`IFactory`](#IFactory) interface. 
+
+[`IMediatorFactory`](#IMediatorFactory) provides building of specifically [`IMediator`](#IMediator)'s.
+
+### MediatorFactory
+
+[`MediatorFactory`](#MediatorFactory) is the base implementation of [`IMediatorFactory`](#IMediatorFactory) and is used by the [`MediatorMapper`](#MediatorMapper). 
+
+This `Factory` is simple in that it calls a default constructor expected on all [`IMediator`](#IMediator) implementations.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The [Extensions](#IExtension) bundled with TinYard include:
 * [Event System](#Event-System-Extension)
 * [Logging](#Logging-Extension)
 * [ViewControllerExtension](#View-Controller-Extension)
+* [Mediator Map Extension](#Mediator-Map-Extension)
 
 These [Extensions](#IExtension) can be installed by installing their respective [Extension](#IExtension) class into the [Context](#IContext).
 
@@ -381,6 +382,27 @@ This is to ensure that it can send [`event`](#IEvent)'s to other parts of the fr
 [`ViewRegister`](#ViewRegister) is a Singleton class that provides static access through the `Instance` property.
 
 The job of [`ViewRegister`](#ViewRegister) is to provide a place where all [`View`](#View)'s are accessible - So that they can be injected into, listened to, or anything else.
+
+## Mediator Map Extension
+
+### About the Extension
+
+The [Mediator Map Extension](#Mediator-Map-Extension) provides:
+
+* The base impl of [`IMediator`](#IMediator), [`Mediator`](#Mediator)
+* The [`MediatorMapper`](#MediatorMapper)
+
+#### Extension and Configurations
+
+To install the [Mediator Map Extension](#Mediator-Map-Extension), install the [`MediatorMapExtension`](#Mediator-Map-Extension) class into your [Context](#IContext).
+
+Currently, there are no configurations for the Extension.
+
+### IMediator
+
+### Mediator
+
+### MediatorMapper
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ Below is the Factories available or in-use in TinYard.
 
 Factories should be providing creation of specific objects, usually including injecting into them upon creation.
 
+#### IFactory
+
+All [`Factories`](#Factories) should be extending this interface.
+
+This is to ensure that every `Factory` is simple and usable.
+
+It is expected that most, if not all, [`Factories`](#Factories) will override the `Build` method with a more clear definition.
+
 #### MappingValueFactory
 
 The [`MappingValueFactory`](#MappingValueFactory) is used by the [`ValueMapper`](#ValueMapper), and aids in creation of [`IMappingObject`](#IMappingObject)'s values.
@@ -376,6 +384,8 @@ Currently, there are no configurations for the Extension.
 [`View`](#View) does no more than register itself to the [`ViewRegister`](#ViewRegister) upon creation.
 
 This is to ensure that it can send [`event`](#IEvent)'s to other parts of the framework.
+
+[`View`](#View) also has a public [`IEventDispatcher`](#IEventDispatcher) property. This is so that it can `Dispatch` events to anything listening.
 
 ### ViewRegister
 

--- a/TinYard.Tests/TestClasses/TestMediator.cs
+++ b/TinYard.Tests/TestClasses/TestMediator.cs
@@ -9,10 +9,6 @@ namespace TinYard.Tests.TestClasses
         [Inject]
         public TestView View;
 
-        public TestMediator()
-        {
-        }
-
         public override void Configure()
         {
         }

--- a/TinYard.Tests/TestClasses/TestMediator.cs
+++ b/TinYard.Tests/TestClasses/TestMediator.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TinYard.Extensions.MediatorMap.API.Base;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class TestMediator : Mediator
+    {
+        public TestMediator()
+        {
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestMediator.cs
+++ b/TinYard.Tests/TestClasses/TestMediator.cs
@@ -1,13 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using TinYard.Extensions.MediatorMap.API.Base;
+﻿using TinYard.Extensions.MediatorMap.API.Base;
+using TinYard.Extensions.ViewController.Tests.MockClasses;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Tests.TestClasses
 {
     public class TestMediator : Mediator
     {
+        [Inject]
+        public TestView View;
+
         public TestMediator()
+        {
+        }
+
+        public override void Configure()
         {
         }
     }

--- a/TinYard.Tests/TestClasses/TestMediator.cs
+++ b/TinYard.Tests/TestClasses/TestMediator.cs
@@ -1,4 +1,6 @@
-﻿using TinYard.Extensions.MediatorMap.API.Base;
+﻿using System;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.ViewController.Tests.MockClasses;
 using TinYard.Framework.Impl.Attributes;
 
@@ -9,8 +11,14 @@ namespace TinYard.Tests.TestClasses
         [Inject]
         public TestView View;
 
+        public event Action OnViewEventHeard;
+        public event Action OnContextEventHeard;
+
         public override void Configure()
         {
+            AddViewListener(TestEvent.Type.Test1, () => OnViewEventHeard?.Invoke());
+
+            AddContextListener(TestEvent.Type.Test1, () => OnContextEventHeard?.Invoke());
         }
     }
 }

--- a/TinYard.Tests/TestClasses/TestView.cs
+++ b/TinYard.Tests/TestClasses/TestView.cs
@@ -1,9 +1,14 @@
 ﻿using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Extensions.ViewController.Impl.Base;
 
 namespace TinYard.Extensions.ViewController.Tests.MockClasses
 {
     public class TestView : IView
     {
-
+        public TestView()
+        {
+            //Register if possible
+            ViewRegister.Register(this);
+        }
     }
 }

--- a/TinYard.Tests/TestClasses/TestView.cs
+++ b/TinYard.Tests/TestClasses/TestView.cs
@@ -1,14 +1,8 @@
-﻿using TinYard.Extensions.ViewController.API.Interfaces;
-using TinYard.Extensions.ViewController.Impl.Base;
+﻿using TinYard.Extensions.ViewController.Impl.Base;
 
 namespace TinYard.Extensions.ViewController.Tests.MockClasses
 {
-    public class TestView : IView
+    public class TestView : View
     {
-        public TestView()
-        {
-            //Register if possible
-            ViewRegister.Register(this);
-        }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Factories;
@@ -34,6 +35,16 @@ namespace TinYard.Extensions.MediatorMap.Tests
         public void MediatorFactory_Builds_Mediator()
         {
             Assert.IsNotNull(_factory.Build<TestMediator>());
+        }
+
+        [TestMethod]
+        public void MediatorFactory_Builds_Correct_Type()
+        {
+            Type expected = typeof(TestMediator);
+
+            Type actual = _factory.Build<TestMediator>().GetType();
+
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorFactoryTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.Impl.Factories;
+using TinYard.Framework.API.Interfaces;
+using TinYard.Tests.TestClasses;
+
+namespace TinYard.Extensions.MediatorMap.Tests
+{
+    [TestClass]
+    public class MediatorFactoryTests
+    {
+        private IMediatorFactory _factory;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _factory = new MediatorFactory();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _factory = null;
+        }
+
+        [TestMethod]
+        public void MediatorFactory_Is_IFactory()
+        {
+            Assert.IsInstanceOfType(_factory, typeof(IFactory));
+        }
+
+        [TestMethod]
+        public void MediatorFactory_Builds_Mediator()
+        {
+            Assert.IsNotNull(_factory.Build<TestMediator>());
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
 
 namespace TinYard.Extensions.MediatorMap.Tests
 {
@@ -31,6 +32,20 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
         [TestMethod]
         public void Context_Installs_Extension()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+        }
+
+        [TestMethod]
+        public void Extension_Maps_MediatorMapper()
+        {
+            SetupExtension();
+
+            Assert.IsNotNull(_context.Mapper.GetMappingValue<IMediatorMapper>());
+        }
+
+        private void SetupExtension()
         {
             _context.Install(_extension);
             _context.Initialize();

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.Tests
+{
+    [TestClass]
+    public class MediatorMapExtensionTests
+    {
+        private IContext _context;
+        private MediatorMapExtension _extension;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context = new Context();
+            _extension = new MediatorMapExtension();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _context = null;
+            _extension = null;
+        }
+
+        [TestMethod]
+        public void MediatorMapExtension_Is_IExtension()
+        {
+            Assert.IsInstanceOfType(_extension, typeof(IExtension));
+        }
+
+        [TestMethod]
+        public void Context_Installs_Extension()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
+using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Extensions.ViewController.Tests.MockClasses;
+using TinYard.Tests.TestClasses;
 
 namespace TinYard.Extensions.MediatorMap.Tests
 {
@@ -32,6 +36,25 @@ namespace TinYard.Extensions.MediatorMap.Tests
         public void MediatorMapper_Is_IMediatorMapper()
         {
             Assert.IsInstanceOfType(_mapper, typeof(IMediatorMapper));
+        }
+
+        [TestMethod]
+        public void MediatorMapper_Maps_Mediator_To_View()
+        {
+            var expected = MapTestMediator();
+            var actual = _mapper.GetMapping<TestView>().Mediator;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        private TestMediator MapTestMediator()
+        {
+            var view = new TestView();
+            var mediator = new TestMediator();
+
+            _mapper.Map<TestView>().ToMediator(mediator);
+
+            return mediator;
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -4,6 +4,9 @@ using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
 using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Extensions.ViewController;
+using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Extensions.ViewController.Impl.Base;
 using TinYard.Extensions.ViewController.Tests.MockClasses;
 using TinYard.Tests.TestClasses;
 
@@ -59,7 +62,21 @@ namespace TinYard.Extensions.MediatorMap.Tests
         [TestMethod]
         public void Mapper_Injects_Mediator_With_View()
         {
+            //Setup ViewRegister and Injector for our mapper
+            Context context = new Context();
+            context.Install(new ViewControllerExtension());
+            context.Initialize();
+
+            //Needs to be setup correctly for injection
+            _mapper = new MediatorMapper(context.Injector, context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister);
+
+
             TestMediator testMediator = new TestMediator();
+
+            _mapper.Map<TestView>().ToMediator(testMediator);
+
+            //Calling this so that it internally gets registered, triggering the injection into the Mediator
+            TestView view = new TestView();
 
             Assert.IsNotNull(testMediator.View);
         }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -27,12 +27,6 @@ namespace TinYard.Extensions.MediatorMap.Tests
         }
 
         [TestMethod]
-        public void MediatorMapper_Is_IMapper()
-        {
-            Assert.IsInstanceOfType(_mapper, typeof(IMapper));
-        }
-
-        [TestMethod]
         public void MediatorMapper_Is_IMediatorMapper()
         {
             Assert.IsInstanceOfType(_mapper, typeof(IMediatorMapper));
@@ -41,20 +35,25 @@ namespace TinYard.Extensions.MediatorMap.Tests
         [TestMethod]
         public void MediatorMapper_Maps_Mediator_To_View()
         {
-            var expected = MapTestMediator();
+            var view = new TestView();
+            var expected = new TestMediator();
+            _mapper.Map(view).ToMediator(expected);
+
             var actual = _mapper.GetMapping<TestView>().Mediator;
 
             Assert.AreEqual(expected, actual);
         }
 
-        private TestMediator MapTestMediator()
+        [TestMethod]
+        public void MediatorMapper_Fetches_View_On_Generic_Map()
         {
-            var view = new TestView();
             var mediator = new TestMediator();
 
-            _mapper.Map<TestView>().ToMediator(mediator);
+            var expected = _mapper.Map<TestView>().ToMediator(mediator);
 
-            return mediator;
+            var actual = _mapper.GetMapping<TestView>();
+
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using TinYard.API.Interfaces;
+using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
 using TinYard.Extensions.MediatorMap.Impl.VO;
@@ -61,11 +62,12 @@ namespace TinYard.Extensions.MediatorMap.Tests
         }
 
         [TestMethod]
-        public void Mapper_Injects_Mediator_With_View()
+        public void Mapper_Injects_Mediator_Correctly()
         {
             //Setup ViewRegister and Injector for our mapper
             Context context = new Context();
             context.Install(new ViewControllerExtension());
+            context.Mapper.Map<IEventDispatcher>().ToValue(new EventSystem.Impl.EventDispatcher(context));
             context.Initialize();
 
             //Needs to be setup correctly for injection
@@ -79,6 +81,8 @@ namespace TinYard.Extensions.MediatorMap.Tests
             TestView view = new TestView();
 
             Assert.IsNotNull(testMediator.View);
+            Assert.IsNotNull(testMediator.Dispatcher);
+            Assert.IsNotNull(testMediator.ViewComponent);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -55,5 +55,13 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void Mapper_Injects_Mediator_With_View()
+        {
+            TestMediator testMediator = new TestMediator();
+
+            Assert.IsNotNull(testMediator.View);
+        }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Runtime.InteropServices;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
@@ -20,7 +21,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
         [TestInitialize]
         public void Setup()
         {
-            _mapper = new MediatorMapper();
+            _mapper = new MediatorMapper(new Context());
         }
 
         [TestCleanup]
@@ -68,8 +69,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
             context.Initialize();
 
             //Needs to be setup correctly for injection
-            _mapper = new MediatorMapper(context.Injector, context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister);
-
+            _mapper = new MediatorMapper(context, context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister);
 
             TestMediator testMediator = new TestMediator();
 

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.Impl.Mappers;
+
+namespace TinYard.Extensions.MediatorMap.Tests
+{
+    [TestClass]
+    public class MediatorMapperTests
+    {
+        private MediatorMapper _mapper;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mapper = new MediatorMapper();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _mapper = null;
+        }
+
+        [TestMethod]
+        public void MediatorMapper_Is_IMapper()
+        {
+            Assert.IsInstanceOfType(_mapper, typeof(IMapper));
+        }
+
+        [TestMethod]
+        public void MediatorMapper_Is_IMediatorMapper()
+        {
+            Assert.IsInstanceOfType(_mapper, typeof(IMediatorMapper));
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Extensions.MediatorMap.API.Base;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.Tests
+{
+    [TestClass]
+    public class MediatorTests
+    {
+        private Mediator _mediator;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mediator = new Mediator();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _mediator = null;
+        }
+
+        [TestMethod]
+        public void Mediator_Is_IMediator()
+        {
+            Assert.IsInstanceOfType(_mediator, typeof(IMediator));
+        }     
+
+        [TestMethod]
+        public void Mediator_Is_IEventDispatcher()
+        {
+            Assert.IsInstanceOfType(_mediator, typeof(IEventDispatcher));
+        }
+
+        [TestMethod]
+        public void Mediator_Dispatches_Successfully()
+        {
+            bool listenerInvoked = false;
+
+            _mediator.AddListener(TestEvent.Type.Test1, () =>
+            {
+                listenerInvoked = true;
+            });
+
+            _mediator.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            Assert.IsTrue(listenerInvoked);
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
@@ -1,20 +1,23 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Impl;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Tests.TestClasses;
 
 namespace TinYard.Extensions.MediatorMap.Tests
 {
     [TestClass]
     public class MediatorTests
     {
-        private Mediator _mediator;
+        private TestMediator _mediator;
 
         [TestInitialize]
         public void Setup()
         {
-            _mediator = new Mediator();
+            _mediator = new TestMediator();
         }
 
         [TestCleanup]
@@ -30,22 +33,22 @@ namespace TinYard.Extensions.MediatorMap.Tests
         }     
 
         [TestMethod]
-        public void Mediator_Is_IEventDispatcher()
-        {
-            Assert.IsInstanceOfType(_mediator, typeof(IEventDispatcher));
-        }
-
-        [TestMethod]
         public void Mediator_Dispatches_Successfully()
         {
+            //Inject a dispatcher into the Test Mediator
+            Context context = new Context();
+            IEventDispatcher dispatcher = new EventDispatcher();
+            context.Mapper.Map<IEventDispatcher>().ToValue(dispatcher);
+            context.Injector.Inject(_mediator, dispatcher);
+
             bool listenerInvoked = false;
 
-            _mediator.AddListener(TestEvent.Type.Test1, () =>
+            _mediator.Dispatcher.AddListener(TestEvent.Type.Test1, () =>
             {
                 listenerInvoked = true;
             });
 
-            _mediator.Dispatch(new TestEvent(TestEvent.Type.Test1));
+            _mediator.Dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
 
             Assert.IsTrue(listenerInvoked);
         }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
@@ -5,6 +5,7 @@ using TinYard.Extensions.EventSystem.Impl;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.ViewController.Tests.MockClasses;
 using TinYard.Tests.TestClasses;
 
 namespace TinYard.Extensions.MediatorMap.Tests
@@ -35,11 +36,11 @@ namespace TinYard.Extensions.MediatorMap.Tests
         [TestMethod]
         public void Mediator_Dispatches_Successfully()
         {
-            //Inject a dispatcher into the Test Mediator
+            //Inject a dispatcher into the Test Mediator, normally done by MediatorMapper
             Context context = new Context();
             IEventDispatcher dispatcher = new EventDispatcher();
             context.Mapper.Map<IEventDispatcher>().ToValue(dispatcher);
-            context.Injector.Inject(_mediator, dispatcher);
+            context.Injector.Inject(_mediator);
 
             bool listenerInvoked = false;
 
@@ -51,6 +52,45 @@ namespace TinYard.Extensions.MediatorMap.Tests
             _mediator.Dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
 
             Assert.IsTrue(listenerInvoked);
+        }
+
+        [TestMethod]
+        public void Mediator_Hears_Events_Correctly()
+        {
+            //Setup ViewRegister and Injector for our mapper
+            Context context = new Context();
+            IEventDispatcher eventDispatcher = new EventDispatcher(context);
+            context.Mapper.Map<IEventDispatcher>().ToValue(eventDispatcher);
+
+            TestView testView = new TestView();
+
+            //Setup mediator and view pairing
+            context.Injector.Inject(_mediator, testView);
+            context.Injector.Inject(_mediator);
+            _mediator.ViewComponent = testView;
+
+            //Tell Mediator it is ready
+            _mediator.Configure();
+
+            TestEvent testEvent = new TestEvent(TestEvent.Type.Test1);
+
+            bool contextEventHeard = false;
+            _mediator.OnContextEventHeard += () =>
+            {
+                contextEventHeard = true;
+            };
+
+            bool viewEventHeard = false;
+            _mediator.OnViewEventHeard += () =>
+            {
+                viewEventHeard = true;
+            };
+
+            eventDispatcher.Dispatch(testEvent);
+            testView.Dispatcher.Dispatch(testEvent);
+
+            Assert.IsTrue(contextEventHeard);
+            Assert.IsTrue(viewEventHeard);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/ViewController/ViewRegisterTests.cs
+++ b/TinYard.Tests/Tests/Extensions/ViewController/ViewRegisterTests.cs
@@ -56,10 +56,9 @@ namespace TinYard.Extensions.ViewController.Tests
         {
             TestView testView = new TestView();
 
-            bool actual1 = ViewRegister.Register(testView);
             bool actual2 = ViewRegister.Register(testView);
 
-            Assert.IsTrue(actual1);
+            Assert.IsTrue(ViewRegister.Instance.RegisteredViews.Contains(testView));
             Assert.IsFalse(actual2);
         }
     }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -49,5 +49,22 @@ namespace TinYard.Tests
             //Should be the value we mapped (5)
             Assert.AreEqual(injectable.Value, valueToInject);
         }
+
+        [TestMethod]
+        public void Injector_Injects_From_Extra_Injectables()
+        {
+            int valueToInject = 5;
+
+            _injector.AddInjectable(valueToInject.GetType(), valueToInject);
+
+            TestInjectable injectable = new TestInjectable();
+            int preInjectValue = injectable.Value;
+
+            Assert.AreNotEqual(preInjectValue, valueToInject);
+
+            _injector.Inject(injectable);
+
+            Assert.AreEqual(valueToInject, injectable.Value);
+        }
     }
 }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -66,5 +66,20 @@ namespace TinYard.Tests
 
             Assert.AreEqual(valueToInject, injectable.Value);
         }
+
+        [TestMethod]
+        public void Injector_Directly_Injects_Value()
+        {
+            int expected = 5;
+
+            TestInjectable injectable = new TestInjectable();
+            int preInjectValue = injectable.Value;
+
+            Assert.AreNotEqual(preInjectValue, expected);
+
+            _injector.Inject(injectable, expected);
+
+            Assert.AreEqual(expected, injectable.Value);
+        }
     }
 }

--- a/TinYard.Tests/Tests/MappingFactoryTests.cs
+++ b/TinYard.Tests/Tests/MappingFactoryTests.cs
@@ -51,7 +51,7 @@ namespace TinYard.Tests
         {
             Type expected = typeof(TestCreatable);
 
-            object value = _mappingFactory.BuildValue(_testingMappingObject).MappedValue;
+            object value = _mappingFactory.Build(_testingMappingObject).MappedValue;
             Assert.IsInstanceOfType(value, expected);
         }
 
@@ -62,7 +62,7 @@ namespace TinYard.Tests
 
             //Context will be mapped to IContext in Mapper that the Factory is using. 
             //TestCreatable has an IContext dependency in constructor
-            TestCreatable mappedValue = (TestCreatable)_mappingFactory.BuildValue(_testingMappingObject).MappedValue;
+            TestCreatable mappedValue = (TestCreatable)_mappingFactory.Build(_testingMappingObject).MappedValue;
             object actual = mappedValue.Context;
 
             Assert.AreSame(expected, actual);

--- a/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
+++ b/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
@@ -17,22 +17,22 @@ namespace TinYard.Extensions.EventSystem.Impl
             _context = context;
         }
 
-        public bool HasListener(Enum type)
+        public virtual bool HasListener(Enum type)
         {
             return _listeners.ContainsKey(type);
         }
 
-        public void AddListener<T>(Enum type, Action<T> listenerCallback)
+        public virtual void AddListener<T>(Enum type, Action<T> listenerCallback)
         {
             AddListener(type, listenerCallback as Delegate);
         }
 
-        public void AddListener(Enum type, Action listenerCallback)
+        public virtual void AddListener(Enum type, Action listenerCallback)
         {
             AddListener(type, listenerCallback as Delegate);
         }
 
-        public void AddListener(Enum type, Delegate listenerCallback)
+        public virtual void AddListener(Enum type, Delegate listenerCallback)
         {
             if (HasListener(type))
             {
@@ -44,17 +44,17 @@ namespace TinYard.Extensions.EventSystem.Impl
             }
         }
 
-        public void RemoveListener(Enum type, Action listenerCallback)
+        public virtual void RemoveListener(Enum type, Action listenerCallback)
         {
             RemoveListener(type, listenerCallback as Delegate);
         }
 
-        public void RemoveListener<T>(Enum type, Action<T> listenerCallback)
+        public virtual void RemoveListener<T>(Enum type, Action<T> listenerCallback)
         {
             RemoveListener(type, listenerCallback as Delegate);
         }
 
-        public void RemoveListener(Enum type, Delegate listenerCallback)
+        public virtual void RemoveListener(Enum type, Delegate listenerCallback)
         {
             if(HasListener(type))
             {
@@ -66,17 +66,17 @@ namespace TinYard.Extensions.EventSystem.Impl
             }
         }
 
-        public void RemoveAllListeners(Enum type)
+        public virtual void RemoveAllListeners(Enum type)
         {
             _listeners.Remove(type);
         }
 
-        public void RemoveAllListeners()
+        public virtual void RemoveAllListeners()
         {
             _listeners.Clear();
         }
 
-        public void Dispatch(IEvent evt)
+        public virtual void Dispatch(IEvent evt)
         {
             if(HasListener(evt.type))
             {

--- a/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
+++ b/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
@@ -8,9 +8,9 @@ namespace TinYard.Extensions.EventSystem.Impl
 {
     public class EventDispatcher : IEventDispatcher
     {
-        private Dictionary<Enum, Listener> _listeners = new Dictionary<Enum, Listener>();
+        protected Dictionary<Enum, Listener> _listeners = new Dictionary<Enum, Listener>();
 
-        private IContext _context;
+        protected IContext _context;
 
         public EventDispatcher(IContext context = null)
         {

--- a/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
@@ -1,13 +1,17 @@
-﻿using TinYard.Extensions.EventSystem.Impl;
+﻿using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.MediatorMap.API.Base
 {
-    public class Mediator : EventDispatcher, IMediator
+    public abstract class Mediator : IMediator
     {
+        [Inject]
+        public IEventDispatcher Dispatcher;
+
         /// <summary>
         /// Add your listeners here. This will be called once the Mediator has been injected into
         /// </summary>
-        public virtual void Configure() { }
+        public abstract void Configure();
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
@@ -5,6 +5,9 @@ namespace TinYard.Extensions.MediatorMap.API.Base
 {
     public class Mediator : EventDispatcher, IMediator
     {
-       
+        /// <summary>
+        /// Add your listeners here. This will be called once the Mediator has been injected into
+        /// </summary>
+        public virtual void Configure() { }
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
@@ -33,6 +33,51 @@ namespace TinYard.Extensions.MediatorMap.API.Base
         /// </summary>
         public abstract void Configure();
 
+        protected virtual void Dispatch(IEvent evt)
+        {
+            Dispatcher.Dispatch(evt);
+        }
+
+        protected virtual void AddContextListener(Enum type, Action listener)
+        {
+            Dispatcher.AddListener(type, listener);
+        }
+
+        protected virtual void AddContextListener<T>(Enum type, Action<T> listener)
+        {
+            Dispatcher.AddListener<T>(type, listener);
+        }
+
+        protected virtual void AddViewListener(Enum type, Action listener)
+        {
+            _viewDispatcher.AddListener(type, listener);
+        }
+
+        protected virtual void AddViewListener<T>(Enum type, Action<T> listener)
+        {
+            _viewDispatcher.AddListener<T>(type, listener);
+        }
+
+        protected virtual void RemoveContextListener(Enum type, Action listener)
+        {
+            Dispatcher.RemoveListener(type, listener);
+        }
+
+        protected virtual void RemoveContextListener<T>(Enum type, Action<T> listener)
+        {
+            Dispatcher.RemoveListener<T>(type, listener);
+        }
+
+        protected virtual void RemoveViewListener(Enum type, Action listener)
+        {
+            Dispatcher.RemoveListener(type, listener);
+        }
+
+        protected virtual void RemoveViewListener<T>(Enum type, Action<T> listener)
+        {
+            Dispatcher.RemoveListener<T>(type, listener);
+        }
+
         private IEventDispatcher GetDispatcher(object dispatcherContainer)
         {
             if (dispatcherContainer == null)

--- a/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
@@ -1,0 +1,10 @@
+﻿using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.API.Base
+{
+    public class Mediator : EventDispatcher, IMediator
+    {
+       
+    }
+}

--- a/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Base/Mediator.cs
@@ -1,5 +1,8 @@
-﻿using TinYard.Extensions.EventSystem.API.Interfaces;
+﻿using System;
+using System.Reflection;
+using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.ViewController.API.Interfaces;
 using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.MediatorMap.API.Base
@@ -9,9 +12,73 @@ namespace TinYard.Extensions.MediatorMap.API.Base
         [Inject]
         public IEventDispatcher Dispatcher;
 
+        public IView ViewComponent
+        {
+            get
+            {
+                return _view;
+            }
+            set 
+            { 
+                _view = value;
+                _viewDispatcher = GetDispatcher(_view);
+            }
+        }
+
+        private IView _view;
+        private IEventDispatcher _viewDispatcher;
+
         /// <summary>
         /// Add your listeners here. This will be called once the Mediator has been injected into
         /// </summary>
         public abstract void Configure();
+
+        private IEventDispatcher GetDispatcher(object dispatcherContainer)
+        {
+            if (dispatcherContainer == null)
+                return null;
+
+            if (dispatcherContainer is IEventDispatcher)
+                return dispatcherContainer as IEventDispatcher;
+
+            Type dispatcherContainerType = dispatcherContainer.GetType();
+
+            PropertyInfo[] properties = dispatcherContainerType.GetProperties
+                (
+                    BindingFlags.Public |
+                    BindingFlags.Instance |
+                    BindingFlags.FlattenHierarchy
+                );
+
+            foreach(PropertyInfo property in properties)
+            {
+                var propertyValue = property.GetValue(dispatcherContainer);
+                if(propertyValue is IEventDispatcher)
+                {
+                    return propertyValue as IEventDispatcher;
+                }
+            }
+
+            //No properties of that type..
+            //Try Fields
+            FieldInfo[] fields = dispatcherContainerType.GetFields
+                (
+                    BindingFlags.Public |
+                    BindingFlags.Instance |
+                    BindingFlags.FlattenHierarchy
+                );
+
+            foreach (FieldInfo field in fields)
+            {
+                var fieldValue = field.GetValue(dispatcherContainer);
+                if(fieldValue is IEventDispatcher)
+                {
+                    return fieldValue as IEventDispatcher;
+                }
+            }
+
+            //Seems there is no IEventDispatcher!
+            return null;
+        }
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
@@ -2,5 +2,6 @@
 {
     public interface IMediator
     {
+        void Configure();
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
@@ -1,7 +1,11 @@
-﻿namespace TinYard.Extensions.MediatorMap.API.Interfaces
+﻿using TinYard.Extensions.ViewController.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.API.Interfaces
 {
     public interface IMediator
     {
+        IView ViewComponent { get; set; }
+
         void Configure();
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediator.cs
@@ -1,0 +1,6 @@
+﻿namespace TinYard.Extensions.MediatorMap.API.Interfaces
+{
+    public interface IMediator
+    {
+    }
+}

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorFactory.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorFactory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.API.Interfaces
+{
+    public interface IMediatorFactory : IFactory
+    {
+        IMediator Build(Type mediatorType);
+        IMediator Build<T>() where T : IMediator;
+    }
+}

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorFactory.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorFactory.cs
@@ -6,6 +6,6 @@ namespace TinYard.Extensions.MediatorMap.API.Interfaces
     public interface IMediatorFactory : IFactory
     {
         IMediator Build(Type mediatorType);
-        IMediator Build<T>() where T : IMediator;
+        T Build<T>() where T : IMediator;
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -1,0 +1,6 @@
+﻿namespace TinYard.Extensions.MediatorMap.API.Interfaces
+{
+    public interface IMediatorMapper
+    {
+    }
+}

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -9,7 +9,7 @@ namespace TinYard.Extensions.MediatorMap.API.Interfaces
     public interface IMediatorMapper
     {
         event Action<IMediatorMappingObject> OnMediatorMapping;
-        IMediatorFactory MappingFactory { get; }
+        IMediatorFactory MediatorFactory { get; }
 
         IMediatorMappingObject Map<T>() where T : IView;
         IMediatorMappingObject Map(IView view);

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -1,6 +1,24 @@
-﻿namespace TinYard.Extensions.MediatorMap.API.Interfaces
+﻿using System;
+using System.Collections.Generic;
+using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.API.Interfaces
 {
     public interface IMediatorMapper
     {
+        event Action<IMediatorMappingObject> OnMediatorMapping;
+        IMediatorFactory MappingFactory { get; }
+
+        IMediatorMappingObject Map<T>() where T : IView;
+        IMediatorMappingObject Map(IView view);
+
+        IMediatorMappingObject GetMapping<T>() where T : IView;
+        IMediatorMappingObject GetMapping(IView type);
+        IReadOnlyList<IMediatorMappingObject> GetAllMappings();
+
+        object GetMappingMediator<T>() where T : IView;
+        object GetMappingMediator(IView type);
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Extensions.MediatorMap.API.VO;
 using TinYard.Extensions.ViewController.API.Interfaces;
-using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.MediatorMap.API.Interfaces
 {

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMappingObject.cs
@@ -2,7 +2,7 @@
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.ViewController.API.Interfaces;
 
-namespace TinYard.Extensions.MediatorMap.Impl.VO
+namespace TinYard.Extensions.MediatorMap.API.VO
 {
     public interface IMediatorMappingObject
     {

--- a/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
@@ -8,7 +8,7 @@ namespace TinYard.Extensions.MediatorMap.Impl.Factories
     {
         public IMediator Build(Type mediatorType)
         {
-            if (mediatorType != typeof(IMediator) || mediatorType == null)
+            if (!typeof(IMediator).IsAssignableFrom(mediatorType) || mediatorType == null)
                 return null;
 
             return Activator.CreateInstance(mediatorType) as IMediator;

--- a/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.Impl.Factories
+{
+    public class MediatorFactory : IMediatorFactory
+    {
+        public IMediator Build(Type mediatorType)
+        {
+            if (mediatorType != typeof(IMediator) || mediatorType == null)
+                return null;
+
+            return Activator.CreateInstance(mediatorType) as IMediator;
+        }
+
+        public IMediator Build<T>() where T : IMediator
+        {
+            return Build(typeof(T));
+        }
+
+        public object Build(params object[] args)
+        {
+            List<IMediator> mediators = new List<IMediator>();
+
+            foreach(object arg in args)
+            {
+                mediators.Add(Build(arg.GetType()));
+            }
+
+            return mediators;
+        }
+    }
+}

--- a/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Factories/MediatorFactory.cs
@@ -14,9 +14,9 @@ namespace TinYard.Extensions.MediatorMap.Impl.Factories
             return Activator.CreateInstance(mediatorType) as IMediator;
         }
 
-        public IMediator Build<T>() where T : IMediator
+        public T Build<T>() where T : IMediator
         {
-            return Build(typeof(T));
+            return (T)Build(typeof(T));
         }
 
         public object Build(params object[] args)

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -1,13 +1,51 @@
-﻿using TinYard.Extensions.MediatorMap.API.Interfaces;
+﻿using System;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Mappers;
 
 namespace TinYard.Extensions.MediatorMap.Impl.Mappers
 {
-    public class MediatorMapper : ValueMapper, IMediatorMapper
+    public class MediatorMapper : IMapper<IMediatorMappingObject>, IMediatorMapper
     {
         public MediatorMapper()
         {
             //_mappingFactory = new MediatorFactory(this);
+        }
+
+        public IMappingFactory MappingFactory => throw new NotImplementedException();
+
+        public event Action<IMediatorMappingObject> OnValueMapped;
+
+        public System.Collections.Generic.IReadOnlyList<IMediatorMappingObject> GetAllMappings()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IMediatorMappingObject GetMapping<T2>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IMediatorMappingObject GetMapping(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetMappingValue<T2>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetMappingValue(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IMediatorMappingObject Map<T2>(bool autoInitializeValue = false)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -94,11 +94,20 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
         {
             IMediatorMappingObject mapping = GetMapping(view);
 
-            IMediator builtMediator = _mediatorFactory.Build(mapping.Mediator.GetType());
+            Type mediatorType = mapping.Mediator.GetType();
+            IMediator mediator;
+            if(mediatorType.IsInstanceOfType(mapping.Mediator))
+            {
+                mediator = mapping.Mediator;
+            }
+            else
+            {
+                mediator = _mediatorFactory.Build(mapping.Mediator.GetType());
+            }
 
-            _injector.Inject(builtMediator);
+            _injector.Inject(mediator);
 
-            builtMediator.Configure();
+            mediator.Configure();
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -1,51 +1,66 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.VO;
+using TinYard.Extensions.ViewController.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Mappers;
 
 namespace TinYard.Extensions.MediatorMap.Impl.Mappers
 {
-    public class MediatorMapper : IMapper<IMediatorMappingObject>, IMediatorMapper
+    public class MediatorMapper : IMediatorMapper
     {
+        public event Action<IMediatorMappingObject> OnValueMapped;
+
+        public IMappingFactory MappingFactory => throw new NotImplementedException();
+
+        private List<IMediatorMappingObject> _mappingObjects = new List<IMediatorMappingObject>();
+
         public MediatorMapper()
         {
             //_mappingFactory = new MediatorFactory(this);
         }
 
-        public IMappingFactory MappingFactory => throw new NotImplementedException();
-
-        public event Action<IMediatorMappingObject> OnValueMapped;
-
-        public System.Collections.Generic.IReadOnlyList<IMediatorMappingObject> GetAllMappings()
+        public IMediatorMappingObject Map<T2>(bool autoInitializeValue = false)
         {
-            throw new NotImplementedException();
+            var mappingObj = new MediatorMappingObject().Map<T2>();
+
+            //TODO 
+            // Add Factory use
+
+            if (OnValueMapped != null)
+                mappingObj.OnViewMapped += (mapping) => OnValueMapped.Invoke(mapping);
+
+            _mappingObjects.Add(mappingObj);
+
+            return mappingObj;
         }
 
         public IMediatorMappingObject GetMapping<T2>()
         {
-            throw new NotImplementedException();
+            return GetMapping(typeof(T2));
         }
 
         public IMediatorMappingObject GetMapping(Type type)
         {
-            throw new NotImplementedException();
+            return _mappingObjects.FirstOrDefault(mapping => mapping.View.IsAssignableFrom(type));
+        }
+
+        public IReadOnlyList<IMediatorMappingObject> GetAllMappings()
+        {
+            return _mappingObjects.AsReadOnly();
         }
 
         public object GetMappingValue<T2>()
         {
-            throw new NotImplementedException();
+            return GetMappingValue(typeof(T2));
         }
 
         public object GetMappingValue(Type type)
         {
-            throw new NotImplementedException();
-        }
-
-        public IMediatorMappingObject Map<T2>(bool autoInitializeValue = false)
-        {
-            throw new NotImplementedException();
+            return GetMapping(type)?.Mediator;
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Factories;
@@ -20,19 +21,21 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
 
         private List<IMediatorMappingObject> _mappingObjects = new List<IMediatorMappingObject>();
 
-        private IViewRegister _viewRegister;
+        private IContext _context;
         private IInjector _injector;
+        private IViewRegister _viewRegister;
 
-        public MediatorMapper(IInjector injector, IViewRegister viewRegister) : this()
+        public MediatorMapper(IContext context, IViewRegister viewRegister) : this(context)
         {
-            _injector = injector;
-
             _viewRegister = viewRegister;
             _viewRegister.OnViewRegistered += OnViewRegistered;
         }
 
-        public MediatorMapper()
+        public MediatorMapper(IContext context)
         {
+            _context = context;
+            _injector = _context.Injector;
+
             _mediatorFactory = new MediatorFactory();
         }
 
@@ -105,7 +108,7 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
                 mediator = _mediatorFactory.Build(mapping.Mediator.GetType());
             }
 
-            _injector.Inject(mediator);
+            _injector.Inject(mediator, view);
 
             mediator.Configure();
         }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using TinYard.API.Interfaces;
-using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.VO;
 using TinYard.Extensions.MediatorMap.Impl.Factories;
 using TinYard.Extensions.MediatorMap.Impl.VO;
 using TinYard.Extensions.ViewController.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
-using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.MediatorMap.Impl.Mappers
 {

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -108,7 +108,9 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
                 mediator = _mediatorFactory.Build(mapping.Mediator.GetType());
             }
 
+            mediator.ViewComponent = view;
             _injector.Inject(mediator, view);
+            _injector.Inject(mediator);//Ensure any other injections are provided too
 
             mediator.Configure();
         }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using TinYard.Extensions.MediatorMap.API.Base;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Factories;
 using TinYard.Extensions.MediatorMap.Impl.VO;
 using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.MediatorMap.Impl.Mappers
 {
@@ -12,14 +15,25 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
     {
         public event Action<IMediatorMappingObject> OnMediatorMapping;
 
-        public IMediatorFactory MappingFactory { get { return _mappingFactory; } }
-        protected IMediatorFactory _mappingFactory;
+        public IMediatorFactory MediatorFactory { get { return _mediatorFactory; } }
+        protected IMediatorFactory _mediatorFactory;
 
         private List<IMediatorMappingObject> _mappingObjects = new List<IMediatorMappingObject>();
 
+        private IViewRegister _viewRegister;
+        private IInjector _injector;
+
+        public MediatorMapper(IInjector injector, IViewRegister viewRegister) : this()
+        {
+            _injector = injector;
+
+            _viewRegister = viewRegister;
+            _viewRegister.OnViewRegistered += OnViewRegistered;
+        }
+
         public MediatorMapper()
         {
-            _mappingFactory = new MediatorFactory();
+            _mediatorFactory = new MediatorFactory();
         }
 
         public IMediatorMappingObject Map<T>() where T : IView
@@ -74,6 +88,17 @@ namespace TinYard.Extensions.MediatorMap.Impl.Mappers
         public object GetMappingMediator(IView view)
         {
             return GetMapping(view)?.Mediator;
+        }
+
+        private void OnViewRegistered(IView view)
+        {
+            IMediatorMappingObject mapping = GetMapping(view);
+
+            IMediator builtMediator = _mediatorFactory.Build(mapping.Mediator.GetType());
+
+            _injector.Inject(builtMediator);
+
+            builtMediator.Configure();
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/Mappers/MediatorMapper.cs
@@ -1,0 +1,13 @@
+﻿using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Impl.Mappers;
+
+namespace TinYard.Extensions.MediatorMap.Impl.Mappers
+{
+    public class MediatorMapper : ValueMapper, IMediatorMapper
+    {
+        public MediatorMapper()
+        {
+            //_mappingFactory = new MediatorFactory(this);
+        }
+    }
+}

--- a/TinYard/Extensions/MediatorMap/Impl/VO/IMediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/IMediatorMappingObject.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.ViewController.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.Impl.VO
+{
+    public interface IMediatorMappingObject
+    {
+        Type View { get; }
+        Type Mediator { get; }
+
+        event Action<IMediatorMappingObject> OnViewMapped;
+
+        IMediatorMappingObject Map<T>();
+
+        IMediatorMappingObject ToMediator<T>() where T : IMediator;
+        IMediatorMappingObject ToMediator(IMediator mediator);
+    }
+}

--- a/TinYard/Extensions/MediatorMap/Impl/VO/IMediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/IMediatorMappingObject.cs
@@ -6,12 +6,14 @@ namespace TinYard.Extensions.MediatorMap.Impl.VO
 {
     public interface IMediatorMappingObject
     {
-        Type View { get; }
-        Type Mediator { get; }
+        IView View { get; }
+        Type ViewType { get; }
+        IMediator Mediator { get; }
 
-        event Action<IMediatorMappingObject> OnViewMapped;
+        event Action<IMediatorMappingObject> OnMediatorMapped;
 
-        IMediatorMappingObject Map<T>();
+        IMediatorMappingObject Map<T>() where T : IView;
+        IMediatorMappingObject Map(IView view);
 
         IMediatorMappingObject ToMediator<T>() where T : IMediator;
         IMediatorMappingObject ToMediator(IMediator mediator);

--- a/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.ViewController.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap.Impl.VO
+{
+    public class MediatorMappingObject : IMediatorMappingObject
+    {
+        public Type View { get; private set; }
+
+        public Type Mediator { get; private set; }
+
+        public event Action<IMediatorMappingObject> OnViewMapped;
+
+        public IMediatorMappingObject Map<T>()
+        {
+            View = typeof(T);
+
+            return this;
+        }
+
+        public IMediatorMappingObject ToMediator<T>() where T : IMediator
+        {
+            Mediator = typeof(T);
+
+            return this;
+        }
+
+        public IMediatorMappingObject ToMediator(IMediator mediator)
+        {
+            Mediator = mediator.GetType();
+
+            return this;
+        }
+    }
+}

--- a/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
@@ -1,34 +1,66 @@
 ﻿using System;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Impl.VO;
 
 namespace TinYard.Extensions.MediatorMap.Impl.VO
 {
     public class MediatorMappingObject : IMediatorMappingObject
     {
-        public Type View { get; private set; }
+        public IView View { get; private set; }
 
-        public Type Mediator { get; private set; }
-
-        public event Action<IMediatorMappingObject> OnViewMapped;
-
-        public IMediatorMappingObject Map<T>()
+        public Type ViewType
         {
-            View = typeof(T);
+            get
+            {
+                return _internalMappingObject.MappedType;
+            }
+        }
+
+        public IMediator Mediator 
+        { 
+            get
+            {
+                return _internalMappingObject.MappedValue as IMediator;
+            }
+        }
+
+        public event Action<IMediatorMappingObject> OnMediatorMapped;
+
+        private IMappingObject _internalMappingObject;
+
+        public MediatorMappingObject(IMappingObject internalMappingObject = null)
+        {
+            _internalMappingObject = internalMappingObject ?? new MappingObject();//If null, create a new mapping obj
+            _internalMappingObject.OnValueMapped += (mappingObj) => OnMediatorMapped?.Invoke(this);
+        }
+
+        public IMediatorMappingObject Map<T>() where T : IView
+        {
+            _internalMappingObject.Map<T>();
+
+            return this;
+        }
+
+        public IMediatorMappingObject Map(IView view)
+        {
+            _internalMappingObject.Map(view.GetType());
+
+            View = view;
 
             return this;
         }
 
         public IMediatorMappingObject ToMediator<T>() where T : IMediator
         {
-            Mediator = typeof(T);
+            _internalMappingObject.ToValue<T>();
 
             return this;
         }
 
         public IMediatorMappingObject ToMediator(IMediator mediator)
         {
-            Mediator = mediator.GetType();
+            _internalMappingObject.ToValue(mediator);
 
             return this;
         }

--- a/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.VO;
 using TinYard.Extensions.ViewController.API.Interfaces;
 using TinYard.Impl.VO;
 

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -23,11 +23,11 @@ namespace TinYard.Extensions.MediatorMap
             IViewRegister viewRegister = _context.Mapper.GetMapping<IViewRegister>()?.MappedValue as IViewRegister;
             IInjector injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
 
-            MediatorMapper mediatorMapper = new MediatorMapper();
+            MediatorMapper mediatorMapper = new MediatorMapper(_context);
             
             if (viewRegister != null && injector != null)
             {
-                mediatorMapper = new MediatorMapper(injector, viewRegister);
+                mediatorMapper = new MediatorMapper(_context, viewRegister);
             }
 
             _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -20,13 +20,16 @@ namespace TinYard.Extensions.MediatorMap
 
         private void OnContextInitialized()
         {
-            var viewRegister = _context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister;
-            var injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
+            IViewRegister viewRegister = _context.Mapper.GetMapping<IViewRegister>()?.MappedValue as IViewRegister;
+            IInjector injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
 
-            if (viewRegister == null || injector == null)
-                return;
+            MediatorMapper mediatorMapper = new MediatorMapper();
+            
+            if (viewRegister != null && injector != null)
+            {
+                mediatorMapper = new MediatorMapper(injector, viewRegister);
+            }
 
-            var mediatorMapper = new MediatorMapper(injector, viewRegister);
             _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
         }
     }

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -1,4 +1,6 @@
 ﻿using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.Impl.Mappers;
 
 namespace TinYard.Extensions.MediatorMap
 {
@@ -6,7 +8,7 @@ namespace TinYard.Extensions.MediatorMap
     {
         public void Install(IContext context)
         {
-            throw new System.NotImplementedException();
+            context.Mapper.Map<IMediatorMapper>().ToValue(new MediatorMapper());
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -1,14 +1,33 @@
-﻿using TinYard.API.Interfaces;
+﻿using System;
+using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
+using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.MediatorMap
 {
     public class MediatorMapExtension : IExtension
     {
+        private IContext _context;
+
         public void Install(IContext context)
         {
-            context.Mapper.Map<IMediatorMapper>().ToValue(new MediatorMapper());
+            _context = context;
+
+            _context.PostConfigsInstalled += OnContextInitialized;
+        }
+
+        private void OnContextInitialized()
+        {
+            //var viewRegister = _context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister;
+            //var injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
+
+            //if (viewRegister == null || injector == null)
+            //    return;
+
+            var mediatorMapper = new MediatorMapper();
+            _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -17,8 +17,6 @@ namespace TinYard.Extensions.MediatorMap
         {
             _context = context;
 
-            _context.Mapper.Map<IEventDispatcher>().ToValue(new EventDispatcher(_context));
-
             _context.PostConfigsInstalled += OnContextInitialized;
         }
 

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -1,0 +1,12 @@
+﻿using TinYard.API.Interfaces;
+
+namespace TinYard.Extensions.MediatorMap
+{
+    public class MediatorMapExtension : IExtension
+    {
+        public void Install(IContext context)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -20,13 +20,13 @@ namespace TinYard.Extensions.MediatorMap
 
         private void OnContextInitialized()
         {
-            //var viewRegister = _context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister;
-            //var injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
+            var viewRegister = _context.Mapper.GetMappingValue<IViewRegister>() as IViewRegister;
+            var injector = _context.Mapper.GetMappingValue<IInjector>() as IInjector;
 
-            //if (viewRegister == null || injector == null)
-            //    return;
+            if (viewRegister == null || injector == null)
+                return;
 
-            var mediatorMapper = new MediatorMapper();
+            var mediatorMapper = new MediatorMapper(injector, viewRegister);
             _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
         }
     }

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using TinYard.API.Interfaces;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Impl;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
 using TinYard.Extensions.ViewController.API.Interfaces;
@@ -14,6 +16,8 @@ namespace TinYard.Extensions.MediatorMap
         public void Install(IContext context)
         {
             _context = context;
+
+            _context.Mapper.Map<IEventDispatcher>().ToValue(new EventDispatcher(_context));
 
             _context.PostConfigsInstalled += OnContextInitialized;
         }

--- a/TinYard/Extensions/ViewController/API/Interfaces/IViewRegister.cs
+++ b/TinYard/Extensions/ViewController/API/Interfaces/IViewRegister.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace TinYard.Extensions.ViewController.API.Interfaces
 {
     public interface IViewRegister
     {
+        event Action<IView> OnViewRegistered;
         IReadOnlyList<IView> RegisteredViews { get; }
     }
 }

--- a/TinYard/Extensions/ViewController/Impl/Base/View.cs
+++ b/TinYard/Extensions/ViewController/Impl/Base/View.cs
@@ -1,17 +1,40 @@
-﻿using TinYard.Extensions.ViewController.API.Interfaces;
+﻿using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.ViewController.Impl.Base
 {
     public class View : IView
     {
+        public IEventDispatcher Dispatcher
+        {
+            get
+            {
+                return _dispatcher;
+            }
+            set
+            {
+                _dispatcher = value;
+            }
+        }
+
+        private IEventDispatcher _dispatcher;
+
         public View()
         {
+            _dispatcher = new EventDispatcher();
             Register();
         }
 
         protected virtual void Register()
         {
             ViewRegister.Register(this);
+        }
+
+        protected virtual void Dispatch(IEvent evt)
+        {
+            _dispatcher.Dispatch(evt);
         }
     }
 }

--- a/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
+++ b/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
@@ -26,11 +26,12 @@ namespace TinYard.Extensions.ViewController.Impl.Base
                 }
 
                 OnViewRegister += InjectView;
+                OnViewRegister += AddViewToInjector;
             }
         }
 
         #endregion
-        
+
         public static event Action<IView> OnViewRegister;
         public event Action<IView> OnViewRegistered
         {
@@ -53,6 +54,12 @@ namespace TinYard.Extensions.ViewController.Impl.Base
             }
 
             return registered;
+        }
+
+        private void AddViewToInjector(IView view)
+        {
+            //So that the injector has a reference of all Views
+            _context.Injector.AddInjectable(view.GetType(), view);
         }
 
         private void InjectView(IView view)

--- a/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
+++ b/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
@@ -25,13 +25,18 @@ namespace TinYard.Extensions.ViewController.Impl.Base
                     Instance = this;
                 }
 
-                OnViewRegistered += InjectView;
+                OnViewRegister += InjectView;
             }
         }
 
         #endregion
         
-        public static event Action<IView> OnViewRegistered;
+        public static event Action<IView> OnViewRegister;
+        public event Action<IView> OnViewRegistered
+        {
+            add { OnViewRegister += value; }
+            remove { OnViewRegister -= value; }
+        }
 
         private IContext _context;
         private HashSet<IView> _registeredViews = new HashSet<IView>();
@@ -44,7 +49,7 @@ namespace TinYard.Extensions.ViewController.Impl.Base
 
             if(registered)
             {
-                OnViewRegistered?.Invoke(view);
+                OnViewRegister?.Invoke(view);
             }
 
             return registered;

--- a/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
+++ b/TinYard/Extensions/ViewController/Impl/Base/ViewRegister.cs
@@ -26,7 +26,6 @@ namespace TinYard.Extensions.ViewController.Impl.Base
                 }
 
                 OnViewRegister += InjectView;
-                OnViewRegister += AddViewToInjector;
             }
         }
 
@@ -54,12 +53,6 @@ namespace TinYard.Extensions.ViewController.Impl.Base
             }
 
             return registered;
-        }
-
-        private void AddViewToInjector(IView view)
-        {
-            //So that the injector has a reference of all Views
-            _context.Injector.AddInjectable(view.GetType(), view);
         }
 
         private void InjectView(IView view)

--- a/TinYard/Framework/API/Interfaces/IFactory.cs
+++ b/TinYard/Framework/API/Interfaces/IFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace TinYard.Framework.API.Interfaces
+{
+    public interface IFactory
+    {
+        object Build(params object[] args);
+    }
+}

--- a/TinYard/Framework/API/Interfaces/IInjector.cs
+++ b/TinYard/Framework/API/Interfaces/IInjector.cs
@@ -1,7 +1,11 @@
-﻿namespace TinYard.Framework.API.Interfaces
+﻿using System;
+
+namespace TinYard.Framework.API.Interfaces
 {
     public interface IInjector
     {
+        void AddInjectable(Type injectableType, object injectableObject);
+
         void Inject(object classToInjectInto);
     }
 }

--- a/TinYard/Framework/API/Interfaces/IInjector.cs
+++ b/TinYard/Framework/API/Interfaces/IInjector.cs
@@ -7,5 +7,6 @@ namespace TinYard.Framework.API.Interfaces
         void AddInjectable(Type injectableType, object injectableObject);
 
         void Inject(object classToInjectInto);
+        void Inject(object target, object value);
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using TinYard.Framework.API.Interfaces;
-using TinYard.Impl.VO;
 
 namespace TinYard.API.Interfaces
 {
-    public interface IMapper
+    public interface IMapper<T1>
     {
-        event Action<IMappingObject> OnValueMapped;
+        event Action<T1> OnValueMapped;
         IMappingFactory MappingFactory { get; }
 
-        IMappingObject Map<T>(bool autoInitializeValue = false);
+        T1 Map<T2>(bool autoInitializeValue = false);
 
-        IMappingObject GetMapping<T>();
-        IMappingObject GetMapping(Type type);
-        IReadOnlyList<IMappingObject> GetAllMappings();
+        T1 GetMapping<T2>();
+        T1 GetMapping(Type type);
+        IReadOnlyList<T1> GetAllMappings();
 
-        object GetMappingValue<T>();
+        object GetMappingValue<T2>();
         object GetMappingValue(Type type);
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using TinYard.Framework.API.Interfaces;
+using TinYard.Impl.VO;
 
 namespace TinYard.API.Interfaces
 {
-    public interface IMapper<T1>
+    public interface IMapper
     {
-        event Action<T1> OnValueMapped;
+        event Action<IMappingObject> OnValueMapped;
         IMappingFactory MappingFactory { get; }
 
-        T1 Map<T2>(bool autoInitializeValue = false);
+        IMappingObject Map<T>(bool autoInitializeValue = false);
 
-        T1 GetMapping<T2>();
-        T1 GetMapping(Type type);
-        IReadOnlyList<T1> GetAllMappings();
+        IMappingObject GetMapping<T>();
+        IMappingObject GetMapping(Type type);
+        IReadOnlyList<IMappingObject> GetAllMappings();
 
-        object GetMappingValue<T2>();
+        object GetMappingValue<T>();
         object GetMappingValue(Type type);
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMappingFactory.cs
+++ b/TinYard/Framework/API/Interfaces/IMappingFactory.cs
@@ -2,8 +2,8 @@
 
 namespace TinYard.Framework.API.Interfaces
 {
-    public interface IMappingFactory
+    public interface IMappingFactory : IFactory
     {
-        IMappingObject BuildValue(IMappingObject mappingObject);
+        IMappingObject Build(IMappingObject mappingObject);
     }
 }

--- a/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
+++ b/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
@@ -17,13 +17,31 @@ namespace TinYard.Framework.Impl.Factories
             _mapper = mapper;
         }
 
-        public IMappingObject BuildValue(IMappingObject mappingObject)
+        public object Build(params object[] args)
+        {
+            List<object> builtObjects = new List<object>();
+            foreach(object argument in args)
+            {
+                if(argument is IMappingObject)
+                {
+                    builtObjects.Add(Build(argument as IMappingObject));
+                }
+            }
+
+            return builtObjects.ToArray();
+        }
+
+        public IMappingObject Build(IMappingObject mappingObject)
         {
             Type type = mappingObject.MappedValue as Type;
 
             //In the odd case that the factory is being used when an actual value is already set, we'll get its type
             if (type == null)
                 type = mappingObject.MappedValue.GetType();
+
+            //Last resort, hope it's not an interface
+            if (type == null)
+                type = mappingObject.MappedType;
 
             object[] constructorDependencies = GetConstructorDependencies(type);
 

--- a/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
+++ b/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
@@ -10,9 +10,9 @@ namespace TinYard.Framework.Impl.Factories
 {
     public class MappingValueFactory : IMappingFactory
     {
-        private IMapper<IMappingObject> _mapper;
+        private IMapper _mapper;
 
-        public MappingValueFactory(IMapper<IMappingObject> mapper)
+        public MappingValueFactory(IMapper mapper)
         {
             _mapper = mapper;
         }

--- a/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
+++ b/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
@@ -10,9 +10,9 @@ namespace TinYard.Framework.Impl.Factories
 {
     public class MappingValueFactory : IMappingFactory
     {
-        private IMapper _mapper;
+        private IMapper<IMappingObject> _mapper;
 
-        public MappingValueFactory(IMapper mapper)
+        public MappingValueFactory(IMapper<IMappingObject> mapper)
         {
             _mapper = mapper;
         }

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -9,13 +9,22 @@ namespace TinYard.Framework.Impl.Injectors
 {
     public class TinYardInjector : IInjector
     {
-        IContext _context;
-        IMapper _mapper;
+        private IContext _context;
+        private IMapper _mapper;
+
+        private Dictionary<Type, object> _extraInjectables;
 
         public TinYardInjector(IContext context)
         {
             _context = context;
             _mapper = _context.Mapper;
+
+            _extraInjectables = new Dictionary<Type, object>();
+        }
+
+        public void AddInjectable(Type injectableType, object injectableObject)
+        {
+            _extraInjectables[injectableType] = injectableObject;
         }
 
         public void Inject(object classToInjectInto)
@@ -31,6 +40,10 @@ namespace TinYard.Framework.Impl.Injectors
                 if(_mapper.GetMapping(fieldType) != null)
                 {
                     field.SetValue(classToInjectInto, _mapper.GetMappingValue(fieldType));
+                }
+                else if(_extraInjectables.ContainsKey(fieldType))
+                {
+                    field.SetValue(classToInjectInto, _extraInjectables[fieldType]);
                 }
             }
         }

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -47,5 +47,22 @@ namespace TinYard.Framework.Impl.Injectors
                 }
             }
         }
+
+        public void Inject(object target, object value)
+        {
+            List<FieldInfo> injectables = InjectAttribute.GetInjectables(target.GetType());
+
+            Type valueType = value.GetType();
+
+            foreach(FieldInfo field in injectables)
+            {
+                Type fieldType = field.FieldType;
+
+                if(valueType == fieldType || fieldType.IsAssignableFrom(valueType))
+                {
+                    field.SetValue(target, value);
+                }
+            }
+        }
     }
 }

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -29,7 +29,7 @@ namespace TinYard.Impl.Mappers
             if(autoInitializeValue)
             {
                 mappingObj = mappingObj.ToValue<T>();
-                mappingObj = _mappingFactory.BuildValue(mappingObj);
+                mappingObj = _mappingFactory.Build(mappingObj);
             }
 
 

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
@@ -9,7 +8,7 @@ using TinYard.Impl.VO;
 
 namespace TinYard.Impl.Mappers
 {
-    public class ValueMapper : IMapper<IMappingObject>
+    public class ValueMapper : IMapper
     {
         public event Action<IMappingObject> OnValueMapped;
 

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -9,7 +9,7 @@ using TinYard.Impl.VO;
 
 namespace TinYard.Impl.Mappers
 {
-    public class ValueMapper : IMapper
+    public class ValueMapper : IMapper<IMappingObject>
     {
         public event Action<IMappingObject> OnValueMapped;
 

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -13,10 +13,10 @@ namespace TinYard.Impl.Mappers
     {
         public event Action<IMappingObject> OnValueMapped;
 
-        private List<IMappingObject> _mappingObjects = new List<IMappingObject>();
+        protected List<IMappingObject> _mappingObjects = new List<IMappingObject>();
 
         public IMappingFactory MappingFactory { get { return _mappingFactory; } }
-        private IMappingFactory _mappingFactory;
+        protected IMappingFactory _mappingFactory;
 
         public ValueMapper()
         {

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -10,6 +10,7 @@ namespace TinYard.Impl.VO
         event Action<IMappingObject> OnValueMapped;
 
         IMappingObject Map<T>();
+        IMappingObject Map(Type type);
 
         IMappingObject ToValue<T>(bool autoInitialize = false);
         IMappingObject ToValue(object value);

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -13,9 +13,9 @@ namespace TinYard.Impl.VO
 
         public event Action<IMappingObject> OnValueMapped;
 
-        private IMapper _parentMapper;
+        private IMapper<IMappingObject> _parentMapper;
 
-        public MappingObject(IMapper parentMapper)
+        public MappingObject(IMapper<IMappingObject> parentMapper)
         {
             _parentMapper = parentMapper;
         }

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -15,6 +15,11 @@ namespace TinYard.Impl.VO
 
         private IMapper _parentMapper;
 
+        public MappingObject()
+        {
+
+        }
+
         public MappingObject(IMapper parentMapper)
         {
             _parentMapper = parentMapper;
@@ -22,7 +27,12 @@ namespace TinYard.Impl.VO
 
         public IMappingObject Map<T>()
         {
-            _mappedType = typeof(T);
+            return Map(typeof(T));
+        }
+
+        public IMappingObject Map(Type type)
+        {
+            _mappedType = type;
 
             return this;
         }
@@ -32,7 +42,7 @@ namespace TinYard.Impl.VO
             _mappedValue = typeof(T);
 
             if(autoInitialize)
-                _mappedValue = _parentMapper.MappingFactory.BuildValue(this).MappedValue;
+                _mappedValue = _parentMapper?.MappingFactory.Build(this).MappedValue;
 
             if (OnValueMapped != null)
                 OnValueMapped.Invoke(this);

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -13,9 +13,9 @@ namespace TinYard.Impl.VO
 
         public event Action<IMappingObject> OnValueMapped;
 
-        private IMapper<IMappingObject> _parentMapper;
+        private IMapper _parentMapper;
 
-        public MappingObject(IMapper<IMappingObject> parentMapper)
+        public MappingObject(IMapper parentMapper)
         {
             _parentMapper = parentMapper;
         }

--- a/TinYard/TinYard.csproj
+++ b/TinYard/TinYard.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\MediatorMap\Impl\Factories\" />
+  </ItemGroup>
+
 </Project>

--- a/TinYard/TinYard.csproj
+++ b/TinYard/TinYard.csproj
@@ -4,8 +4,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Extensions\MediatorMap\Impl\Factories\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The `MediatorMapExtension`.

This extension aims to provide a place to `Map` mediators and views together - The `MediatorMapper`.

This `Mapper` will build a `Mediator` when the associated `View` type has been registered to the `ViewRegister`, and attach them together so that a `View` can dispatch to everything else connected to the `IContext`.

* What is new?
  * Added `MediatorMapExtension`
  * Added `IMediator` interface
  * Added `Mediator` implementation of `IMediator`
  * Added `IMediatorMapper` interface
  * Added `MediatorMapper` implementation of `IMediatorMapper`
  * Added `IFactory` interface
  * Added `IMediatorFactory` interface that inherits `IFactory`
  * Added `MediatorFactory` that inherits `IMediatorFactory`
  * Added `IMediatorMappingObject` interface
  * Added `MediatorMappingObject` implementation of `IMediatorMappingObject`

* What has changed?
  * `IInjector` interface has override of `Inject` method, providing direct injection of a value into a target. `Inject(object target, object value)`.
  * `IInjector` interface also provides a `AddInjectable(Type injectableType, object injectableObject)` method. This is so that each `IInjector` can have an internal collection of things to inject with.
  * Updated `TinYardInjector` with `IInjector` changes.
  * Added test to InjectorTests to check these new changes.
  * `IMappingFactory` now inherits `IFactory`, `BuildValue` method signature changed to `Build`.
  * `MappingValueFactory` updated to reflect `IMappingFactory` signature change. Tests now reflect this too.
  * `MappingValueFactory` now also has another check for when type is null to try and salvage. Line42-45.
  * `ValueMapper` now more flexible to inherit.
  * `IMappingObject` has new public `Map(Type type)` method.
  * `MappingObject` updated to reflect this. Was done internally already, just exposed now.
  * `TestView` now inherits from base `View` class to ensure it behaves correctly.
  *  ViewRegisterTests class had a slight improvement in clarity and now works correctly with changes.
  * `EventDispatcher` now is more flexible when inherited. Most items made protected if not public or virtual.
  *  `IViewRegister` modified to have non-static event to attach to when `View`'s are registered, as we don't have reference to the Static class when receiving from `Mapper`.
  * `ViewRegister` updated to reflect this, including rename of static `OnViewRegistered` event to `OnViewRegister`.
  * `View` class now has public `IEventDispatcher` property and `Dispatch` method that calls it internally.
  

Related issues?    
Resolves #38 
Resolves #42 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes

Read Me updated to reflect all changes.
