### PR TITLE
Feature/command system

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,60 @@ The [`IMediatorFactory`](#IMediatorFactory) interface extends upon the [`IFactor
 
 This `Factory` is simple in that it calls a default constructor expected on all [`IMediator`](#IMediator) implementations.
 
+## Command System Extension
+
+### Dependencies
+
+The [Command System Extension](#Command-System-Extension) is depdendant on:
+
+* [Event System Extension](#Event-System-Extension)
+
+### About the Extension
+
+The [Command System Extension](#Command-System-Extension) brings [Commands](#ICommand) to TinYard. 
+
+The idea of this is that you can execute one-of code when specific [`event`](#IEvent)'s are dispatched. The most common use-case for this is to fetch data from a `model` and then dispatch that data to somewhere else - Often the same place that the original [`event`](#IEvent) was dispatched from.
+
+A [`Command`](#ICommand) is created when needed by the [`EventCommandMap`](#EventCommandMap), and then left to be garbage collected after it has been 'executed' - They are intended for singular uses, and if you require something that is not then perhaps look at using a `service` or `model`.
+
+#### Extension and Configurations
+
+To install the [Command System Extension](#Command-System-Extension), install the [`CommandSystemExtension`](#Command-System-Extension) class into your [Context](#IContext).
+
+No configurations are available for the [Command System Extension](#Command-System-Extension).
+
+### ICommand
+
+The [`ICommand`](#ICommand) interface is the base of any `Command`. All this interface requires is a method called `Execute()` in your `Command`. 
+
+The `Execute` method is invoked once the `Command` has been created and all injections completed.
+
+### ICommandMap
+
+An [`ICommandMap`](#ICommandMap) simply has to have two `Map` functions that return an [`ICommandMapping`](#ICommandMapping). 
+
+### Event Command Map
+
+The [`Event Command Map`](#Event-Command-Map) is the base impl of [`ICommandMap`](#ICommandMap) that is used link [`event`](#IEvent)'s to [`command`](#ICommand)'s. It ensures that when that specific [`event`](#IEvent) and `type` are dispatched on the mapped [`IEventDispatcher`](#IEventDispatcher), the appropriate [`command`](#ICommand) is created, injected into, and invoked (via the `Execute` method).
+
+Internally it does this by having reference to the mapped [`IEventDispatcher`](#IEventDispatcher) and adding a listener to that, with a callback function that builds and invokes the correct [`command`](#ICommand).
+
+### ICommandFactory
+
+[`ICommandFactory`](#ICommandFactory) is an [`IFactory`](#IFactory) that is made for specifically creating [`ICommand`](#ICommand)'s.
+
+### Command Factory
+
+[`CommandFactory`](#Command-Factory) is the base impl of [`ICommandFactory`](#ICommandFactory) that creates [`ICommand`](#ICommand)'s and injects into them. It also injects the [`event`](#IEvent) that is causing its creation, if it can.
+
+### ICommandMapping
+
+[`ICommandMapping`](#ICommandMapping) is a spin on [`IMappingObject`](#IMappingObject), but changed for keeping a correlation between [`event`](#IEvent)'s and [`command`](#ICommand)'s.
+
+### CommandMapping
+
+[`CommandMapping`](#CommandMapping) is the base impl of [`ICommandMapping`](#ICommandMapping) and is also a spin on [`MappingObject`](#MappingObject).
+
 ---
 
 ## [Contribution](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ The [Extensions](#IExtension) bundled with TinYard include:
 * [Logging](#Logging-Extension)
 * [ViewControllerExtension](#View-Controller-Extension)
 * [Mediator Map Extension](#Mediator-Map-Extension)
+* [Command System Extension](#Command-System-Extension)
 
 These [Extensions](#IExtension) can be installed by installing their respective [Extension](#IExtension) class into the [Context](#IContext).
 

--- a/TinYard.Tests/TestClasses/TestCommand.cs
+++ b/TinYard.Tests/TestClasses/TestCommand.cs
@@ -1,0 +1,14 @@
+﻿using TinYard.Extensions.CommandSystem.API.Interfaces;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class TestCommand : ICommand
+    {
+        public bool ExecuteCalled { get; set; } = false;
+
+        public void Execute()
+        {
+            ExecuteCalled = true;
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestCommand.cs
+++ b/TinYard.Tests/TestClasses/TestCommand.cs
@@ -1,10 +1,19 @@
 ﻿using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Framework.Impl.Attributes;
+using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests.TestClasses
 {
     public class TestCommand : ICommand
     {
-        public bool ExecuteCalled { get; set; } = false;
+        public static bool ExecuteCalled { get; set; } = false;
+
+        [Inject]
+        public TestEvent Evt;
+
+        [Inject]
+        public TestInjectable Injectable;
 
         public void Execute()
         {

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using TinYard.API.Interfaces;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.CommandSystem.Impl.Factories;
-using TinYard.Extensions.EventSystem.API.Interfaces;
-using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Tests.TestClasses;
+using TinYard_Tests.TestClasses;
 
 namespace TinYard.Extensions.CommandSystem.Tests
 {
@@ -13,11 +14,13 @@ namespace TinYard.Extensions.CommandSystem.Tests
     public class CommandFactoryTests
     {
         private ICommandFactory _commandFactory;
+        private IContext _context;
 
         [TestInitialize]
         public void Setup()
         {
-            _commandFactory = new CommandFactory();
+            _context = new Context();
+            _commandFactory = new CommandFactory(_context.Injector);
         }
 
         [TestCleanup]
@@ -50,6 +53,31 @@ namespace TinYard.Extensions.CommandSystem.Tests
             Type expected = typeof(TestCommand);
             var actual = _commandFactory.Build<TestCommand>();
             Assert.IsInstanceOfType(actual, expected);
+        }
+
+        [TestMethod]
+        public void CommandFactory_Injects_Command()
+        {
+            _context.Mapper.Map<TestInjectable>().ToValue(new TestInjectable());
+
+            TestEvent tEvent = new TestEvent(TestEvent.Type.Test1);
+            var command = _commandFactory.Build<TestCommand>(tEvent);
+
+            Assert.IsNotNull(command.Evt);
+            Assert.IsNotNull(command.Injectable);
+        }
+
+        [TestMethod]
+        public void CommandFactory_Injects_Command_Correctly()
+        {
+            var expectedInjectable = new TestInjectable();
+            _context.Mapper.Map<TestInjectable>().ToValue(expectedInjectable);
+
+            TestEvent expectedEvent = new TestEvent(TestEvent.Type.Test1);
+            var command = _commandFactory.Build<TestCommand>(expectedEvent);
+
+            Assert.AreEqual(expectedEvent, command.Evt);
+            Assert.AreEqual(expectedInjectable, command.Injectable);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.CommandSystem.Impl.Factories;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Framework.API.Interfaces;
+using TinYard.Tests.TestClasses;
+
+namespace TinYard.Extensions.CommandSystem.Tests
+{
+    [TestClass]
+    public class CommandFactoryTests
+    {
+        private ICommandFactory _commandFactory;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _commandFactory = new CommandFactory();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _commandFactory = null;
+        }
+
+        [TestMethod]
+        public void CommandFactory_Is_IFactory()
+        {
+            Assert.IsInstanceOfType(_commandFactory, typeof(IFactory));
+        }
+
+        [TestMethod]
+        public void CommandFactory_Is_ICommandFactory()
+        {
+            Assert.IsInstanceOfType(_commandFactory, typeof(ICommandFactory));
+        }
+
+        [TestMethod]
+        public void CommandFactory_Creates_Command()
+        {
+            Assert.IsNotNull(_commandFactory.Build<TestCommand>());
+        }
+
+        [TestMethod]
+        public void CommandFactory_Creates_Correct_Command()
+        {
+            Type expected = typeof(TestCommand);
+            var actual = _commandFactory.Build<TestCommand>();
+            Assert.IsInstanceOfType(actual, expected);
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/CommandSystemExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/CommandSystemExtensionTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem;
+
+namespace TinYard.Extensions.CommandSystem.Tests
+{
+    [TestClass]
+    public class CommandSystemExtensionTests
+    {
+        private CommandSystemExtension _extension;
+        private IContext _context;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _extension = new CommandSystemExtension();
+            _context = new Context();
+            _context.Install(new EventSystemExtension());
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _extension = null;
+        }
+
+        [TestMethod]
+        public void CommandSystemExtension_Is_IExtension()
+        {
+            Assert.IsInstanceOfType(_extension, typeof(IExtension));
+        }
+
+        [TestMethod]
+        public void Context_Installs_Extension()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+        }
+
+        [TestMethod]
+        public void CommandMap_Is_Mapped()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+
+            Assert.IsNotNull(_context.Mapper.GetMappingValue<ICommandMap>());
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/EventCommandMapTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/EventCommandMapTests.cs
@@ -1,15 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.CommandSystem.Impl.CommandMaps;
-using TinYard.Extensions.CommandSystem.Impl.Factories;
-using TinYard.Extensions.EventSystem;
 using TinYard.Extensions.EventSystem.Impl;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
-using TinYard.Framework.API.Interfaces;
 using TinYard.Tests.TestClasses;
-using TinYard_Tests.TestClasses;
 
 namespace TinYard.Extensions.CommandSystem.Tests
 {

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/EventCommandMapTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/EventCommandMapTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.CommandSystem.Impl.CommandMaps;
+using TinYard.Extensions.CommandSystem.Impl.Factories;
+using TinYard.Extensions.EventSystem;
+using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Framework.API.Interfaces;
+using TinYard.Tests.TestClasses;
+using TinYard_Tests.TestClasses;
+
+namespace TinYard.Extensions.CommandSystem.Tests
+{
+    [TestClass]
+    public class EventCommandMapTests
+    {
+        private EventCommandMap _commandMap;
+        private EventDispatcher _dispatcher;
+        private IContext _context;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context = new Context();
+            _dispatcher = new EventDispatcher(_context);
+
+            _commandMap = new EventCommandMap(_dispatcher, _context.Injector);
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _commandMap = null;
+        }
+
+        [TestMethod]
+        public void EventCommandMap_Is_ICommandMap()
+        {
+            Assert.IsInstanceOfType(_commandMap, typeof(ICommandMap));
+        }
+
+        [TestMethod]
+        public void EventCommandMap_Creates_Command_Mapping()
+        {
+            var mapping = _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>();
+
+            Assert.IsNotNull(mapping);
+        }
+
+        [TestMethod]
+        public void EventCommandMap_Creates_Command_On_Event()
+        {
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>();
+
+            Assert.IsFalse(TestCommand.ExecuteCalled);
+
+            _dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            Assert.IsTrue(TestCommand.ExecuteCalled);
+        }
+    }
+}

--- a/TinYard.Tests/TinYard.Tests.csproj
+++ b/TinYard.Tests/TinYard.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TinYard.Tests/TinYard.Tests.csproj
+++ b/TinYard.Tests/TinYard.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommand.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommand.cs
@@ -1,0 +1,7 @@
+﻿namespace TinYard.Extensions.CommandSystem.API.Interfaces
+{
+    public interface ICommand
+    {
+        void Execute();
+    }
+}

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandFactory.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandFactory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.API.Interfaces
+{
+    public interface ICommandFactory : IFactory
+    {
+        ICommand Build<T>() where T : ICommand;
+        ICommand Build(Type commandType);
+    }
+}

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandFactory.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandFactory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem.API.Interfaces
 {
     public interface ICommandFactory : IFactory
     {
-        ICommand Build<T>() where T : ICommand;
-        ICommand Build(Type commandType);
+        T Build<T>(IEvent evtToInject = null) where T : ICommand;
+        ICommand Build(Type commandType, IEvent evtToInject = null);
     }
 }

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMap.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMap.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.API.Interfaces
+{
+    public interface ICommandMap
+    {
+        ICommandMapping Map<T>() where T : IEvent;
+        ICommandMapping Map<T>(Enum type) where T : IEvent;
+    }
+}

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.API.Interfaces
+{
+    public interface ICommandMapping
+    {
+        Type Event { get; }
+        Enum EventType { get; }
+
+        Type Command { get; }
+
+        ICommandMapping Map<T>(Enum type = null) where T : IEvent;
+
+        ICommandMapping ToCommand<T>() where T : ICommand;
+    }
+}

--- a/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
+++ b/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
@@ -1,0 +1,12 @@
+﻿using TinYard.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem
+{
+    public class CommandSystemExtension : IExtension
+    {
+        public void Install(IContext context)
+        {
+            
+        }
+    }
+}

--- a/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
+++ b/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
@@ -1,12 +1,33 @@
-﻿using TinYard.API.Interfaces;
+﻿using System;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.CommandSystem.Impl.CommandMaps;
+using TinYard.Extensions.EventSystem.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem
 {
     public class CommandSystemExtension : IExtension
     {
+        private IContext _context;
+
         public void Install(IContext context)
         {
-            
+            _context = context;
+            _context.PostConfigsInstalled += PostConfigsInstalled;
+        }
+
+        private void PostConfigsInstalled()
+        {
+            var eventDispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>() as IEventDispatcher;
+            var injector = _context.Injector;
+
+            if(eventDispatcher == null || injector == null)
+            {
+                throw new NullReferenceException("Event Dispatcher or Injector are null in CommandSystemExtension");
+            }
+
+            EventCommandMap commandMap = new EventCommandMap(eventDispatcher, injector);
+            _context.Mapper.Map<ICommandMap>().ToValue(commandMap);
         }
     }
 }

--- a/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
@@ -22,7 +22,7 @@ namespace TinYard.Extensions.CommandSystem.Impl.CommandMaps
             _eventDispatcher = eventDispatcher;
             _injector = injector;
 
-            _commandFactory = new CommandFactory();
+            _commandFactory = new CommandFactory(injector);
         }
 
         public ICommandMapping Map<T>() where T : IEvent
@@ -58,9 +58,8 @@ namespace TinYard.Extensions.CommandSystem.Impl.CommandMaps
             if (mapping.Command == null)
                 return;
 
-            ICommand builtCommand = _commandFactory.Build(mapping.Command);
-            _injector.Inject(builtCommand, evt);//Inject the specific invoking event
-            _injector.Inject(builtCommand);//Inject anything else requested
+            //Should be injected into in the Factory
+            ICommand builtCommand = _commandFactory.Build(mapping.Command, evt);
             builtCommand.Execute();//Let the command do its thing
         }
     }

--- a/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.CommandSystem.Impl.Factories;
+using TinYard.Extensions.CommandSystem.Impl.VO;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.Impl.CommandMaps
+{
+    public class EventCommandMap : ICommandMap
+    {
+        private IEventDispatcher _eventDispatcher;
+        private IInjector _injector;
+
+        private ICommandFactory _commandFactory;
+
+        private List<ICommandMapping> _mappings = new List<ICommandMapping>();
+
+        public EventCommandMap(IEventDispatcher eventDispatcher, IInjector injector)
+        {
+            _eventDispatcher = eventDispatcher;
+            _injector = injector;
+
+            _commandFactory = new CommandFactory();
+        }
+
+        public ICommandMapping Map<T>() where T : IEvent
+        {
+            var mapping = AddListener<T>();
+            
+            _mappings.Add(mapping);
+
+            return mapping;
+        }
+
+        public ICommandMapping Map<T>(Enum type) where T : IEvent
+        {
+            var mapping = AddListener<T>(type);
+
+            _mappings.Add(mapping);
+
+            return mapping;
+        }
+
+        private ICommandMapping AddListener<T>(Enum eventType = null) where T : IEvent
+        {
+            ICommandMapping mapping = new CommandMapping();
+            mapping = mapping.Map<T>(eventType);
+
+            _eventDispatcher.AddListener<T>(eventType, (evt)=> ExecuteMapping(mapping, evt));
+
+            return mapping;
+        }
+
+        private void ExecuteMapping(ICommandMapping mapping, IEvent evt)
+        {
+            if (mapping.Command == null)
+                return;
+
+            ICommand builtCommand = _commandFactory.Build(mapping.Command);
+            _injector.Inject(builtCommand, evt);//Inject the specific invoking event
+            _injector.Inject(builtCommand);//Inject anything else requested
+            builtCommand.Execute();//Let the command do its thing
+        }
+    }
+}

--- a/TinYard/Extensions/CommandSystem/Impl/Factories/CommandFactory.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/Factories/CommandFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.Impl.Factories
+{
+    public class CommandFactory : ICommandFactory
+    {
+        public ICommand Build<T>() where T : ICommand
+        {
+            return Build(typeof(T));
+        }
+
+        public ICommand Build(Type commandType)
+        {
+            if (!typeof(ICommand).IsAssignableFrom(commandType))
+                return null;
+
+            return Activator.CreateInstance(commandType) as ICommand;
+        }
+
+        public object Build(params object[] args)
+        {
+            List<ICommand> builtCommands = new List<ICommand>();
+            foreach (object arg in args)
+            {
+                var command = Build(arg.GetType());
+
+                if (command != null)
+                    builtCommands.Add(command);
+            }
+
+            return builtCommands;
+        }
+    }
+}

--- a/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+
+namespace TinYard.Extensions.CommandSystem.Impl.VO
+{
+    public class CommandMapping : ICommandMapping
+    {
+        public Type Event { get; private set; }
+
+        public Enum EventType { get; private set; }
+
+        public Type Command { get; private set; }
+
+        public ICommandMapping Map<T>(Enum type = null) where T : IEvent
+        {
+            Event = typeof(T);
+            EventType = type;
+
+            return this;
+        }
+
+        public ICommandMapping ToCommand<T>() where T : ICommand
+        {
+            Command = typeof(T);
+
+            return this;
+        }
+    }
+}

--- a/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
+++ b/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
@@ -24,6 +24,7 @@ namespace TinYard.Extensions.EventSystem.Impl
 
         public virtual void AddListener<T>(Enum type, Action<T> listenerCallback)
         {
+            //TODO : Make use of T
             AddListener(type, listenerCallback as Delegate);
         }
 


### PR DESCRIPTION
This Merge Request brings with it the `Command System Extension`.

From the ReadMe:

The [Command System Extension](#Command-System-Extension) brings [Commands](#ICommand) to TinYard. 

The idea of this is that you can execute one-of code when specific [`event`](#IEvent)'s are dispatched. The most common use-case for this is to fetch data from a `model` and then dispatch that data to somewhere else - Often the same place that the original [`event`](#IEvent) was dispatched from.

A [`Command`](#ICommand) is created when needed by the [`EventCommandMap`](#EventCommandMap), and then left to be garbage collected after it has been 'executed' - They are intended for singular uses, and if you require something that is not then perhaps look at using a `service` or `model`.

* What is new?
  * `CommandSystemExtension` to install into your `IContext`!
  * `ICommand` interface for all your `Command`s to implement.
  * `ICommandFactory` interface, and base impl in `CommandFactory`. 
  * `ICommandMap` interface, and the base impl in `EventCommandMap`
  * `ICommandMapping` interface and the base impl in `CommandMapping`
* What has changed?
  * Nothing, only new things here!

Related issues?    
Resolves #14 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes
