### PR TITLE
Fix null type error handling

### DIFF
--- a/TinYard.Tests/Tests/Extensions/EventSystem/EventDispatcherTests.cs
+++ b/TinYard.Tests/Tests/Extensions/EventSystem/EventDispatcherTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.Impl;
+using TinYard.Extensions.EventSystem.Impl.Exceptions;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 
 namespace TinYard.Extensions.EventSystem.Tests
@@ -97,6 +98,15 @@ namespace TinYard.Extensions.EventSystem.Tests
 
             Assert.IsTrue(callbackInvoked);
             Assert.IsFalse(incorrectCallbackInvoked);
+        }
+
+        [TestMethod]
+        public void EventDispatcher_Throws_On_Invalid_Event_Type()
+        {
+            Assert.ThrowsException<EventTypeException>(() =>
+           {
+               _eventDispatcher.AddListener(null, () => { });
+           });
         }
     }
 }

--- a/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
+++ b/TinYard/Extensions/EventSystem/Impl/Dispatchers/EventDispatcher.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Impl.Exceptions;
 using TinYard.Extensions.EventSystem.Impl.VO;
 
 namespace TinYard.Extensions.EventSystem.Impl
@@ -19,12 +20,14 @@ namespace TinYard.Extensions.EventSystem.Impl
 
         public virtual bool HasListener(Enum type)
         {
+            if (type == null)
+                throw new EventTypeException("Cannot look for listener of type null");
+
             return _listeners.ContainsKey(type);
         }
 
         public virtual void AddListener<T>(Enum type, Action<T> listenerCallback)
         {
-            //TODO : Make use of T
             AddListener(type, listenerCallback as Delegate);
         }
 
@@ -35,6 +38,9 @@ namespace TinYard.Extensions.EventSystem.Impl
 
         public virtual void AddListener(Enum type, Delegate listenerCallback)
         {
+            if (type == null)
+                throw new EventTypeException("Cannot add listener for type null");
+
             if (HasListener(type))
             {
                 _listeners[type].AddListener(listenerCallback);

--- a/TinYard/Extensions/EventSystem/Impl/Exceptions/EventTypeException.cs
+++ b/TinYard/Extensions/EventSystem/Impl/Exceptions/EventTypeException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace TinYard.Extensions.EventSystem.Impl.Exceptions
+{
+    public class EventTypeException : Exception
+    {
+        public EventTypeException() : base() { }
+
+        public EventTypeException(string message) : base(message) { }
+
+        public EventTypeException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}


### PR DESCRIPTION
Add tests and exception specifically for this case

* What has changed?
  * Added handling of null `type` enum parameter in `AddListener` and `HasListener`. Now throws a `EventTypeException`.

Related issues?    
Resolves #47 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    