### PR TITLE
Fix / Mapping ToValue Generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,17 @@ So, looking at the example used in [Value Mapper](#ValueMapper):
 
 When `Map<T>()` is called on the `ValueMapper`, it returns the `IMappingObject`.
 
-Internally, `Map<T>()` calls `Map<T>()` on a newly created `IMappingObject` and then returns this newly created object. This `Map<T>()` method on IMappingObject should set the `MappedType` to the type of `T`.
+Internally, `Map<T>()` on the `ValueMapper` calls `Map<T>()` on a newly created `IMappingObject` and then returns this newly created object. This `Map<T>()` method on IMappingObject should set the `MappedType` to the type of `T`.
 
-`MappedValue` is then the value that is set with the `ToValue<T>(bool autoInitialize = false)` or `ToValue(object value)` methods.
+`MappedValue` is then the value that is set with the `ToValue(object value)` method.
 
-The `ToValue<T>(bool autoInitialize = false)` function can instantiate a value of type `T` for you if you pass true to the method. It should be doing this via a Factory it has access to.
+The `BuildValue<T>()` function can create the `MappedValue` object of type `T` for you. It should be doing this via a Factory it has access to.
 
 #### MappingObject
 
 `MappingObject` provides a super-simple implementation of [`IMappingObject`](#IMappingObject) that is used by [`ValueMapper`](#ValueMapper). 
 
-`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when `ToValue<T>(bool)` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value.
+`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when `BuildValue<T>` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value.
 
 ### IInjector
 

--- a/TinYard.Tests/Tests/MappingFactoryTests.cs
+++ b/TinYard.Tests/Tests/MappingFactoryTests.cs
@@ -26,7 +26,7 @@ namespace TinYard.Tests
             _mapper = _context.Mapper;
             _mappingFactory = new MappingValueFactory(_mapper);
 
-            _testingMappingObject = _mapper.Map<TestCreatable>().ToValue<TestCreatable>();
+            _testingMappingObject = _mapper.Map<TestCreatable>().BuildValue<TestCreatable>();
         }
 
         [TestCleanup]

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -41,11 +41,11 @@ namespace TinYard.Tests
         }
 
         [TestMethod]
-        public void Mapper_Auto_Creates_Value_Correctly()
+        public void Mapper_Builds_Value_Correctly()
         {
             Type expected = typeof(TestCreatable);
 
-            TestCreatable actual = (TestCreatable)_mapper.Map<TestCreatable>(true).MappedValue;
+            TestCreatable actual = (TestCreatable)_mapper.Map<TestCreatable>().BuildValue<TestCreatable>().MappedValue;
 
             Assert.IsNotNull(actual);
             Assert.IsInstanceOfType(actual, expected);

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -10,7 +10,7 @@ namespace TinYard.API.Interfaces
         event Action<IMappingObject> OnValueMapped;
         IMappingFactory MappingFactory { get; }
 
-        IMappingObject Map<T>(bool autoInitializeValue = false);
+        IMappingObject Map<T>();
 
         IMappingObject GetMapping<T>();
         IMappingObject GetMapping(Type type);

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -22,16 +22,9 @@ namespace TinYard.Impl.Mappers
             _mappingFactory = new MappingValueFactory(this);
         }
 
-        public IMappingObject Map<T>(bool autoInitializeValue = false)
+        public IMappingObject Map<T>()
         {
             var mappingObj = new MappingObject(this).Map<T>();
-
-            if(autoInitializeValue)
-            {
-                mappingObj = mappingObj.ToValue<T>();
-                mappingObj = _mappingFactory.Build(mappingObj);
-            }
-
 
             if (OnValueMapped != null)
                 mappingObj.OnValueMapped += ( mapping ) => OnValueMapped.Invoke(mapping);

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -12,7 +12,7 @@ namespace TinYard.Impl.VO
         IMappingObject Map<T>();
         IMappingObject Map(Type type);
 
-        IMappingObject ToValue<T>(bool autoInitialize = false);
         IMappingObject ToValue(object value);
+        IMappingObject BuildValue<T>();
     }
 }

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -37,12 +37,9 @@ namespace TinYard.Impl.VO
             return this;
         }
 
-        public IMappingObject ToValue<T>(bool autoInitialize = false)
+        public IMappingObject ToValue(object value)
         {
-            _mappedValue = typeof(T);
-
-            if(autoInitialize)
-                _mappedValue = _parentMapper?.MappingFactory.Build(this).MappedValue;
+            _mappedValue = value;
 
             if (OnValueMapped != null)
                 OnValueMapped.Invoke(this);
@@ -50,9 +47,11 @@ namespace TinYard.Impl.VO
             return this;
         }
 
-        public IMappingObject ToValue(object value)
+        public IMappingObject BuildValue<T>()
         {
-            _mappedValue = value;
+            _mappedValue = typeof(T);
+            
+            _mappedValue = _parentMapper?.MappingFactory.Build(this).MappedValue;
 
             if (OnValueMapped != null)
                 OnValueMapped.Invoke(this);

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -51,7 +51,7 @@ namespace TinYard.Impl.VO
         {
             _mappedValue = typeof(T);
             
-            _mappedValue = _parentMapper?.MappingFactory.Build(this).MappedValue;
+            _mappedValue = _parentMapper?.MappingFactory?.Build(this).MappedValue;
 
             if (OnValueMapped != null)
                 OnValueMapped.Invoke(this);


### PR DESCRIPTION
Clarity MR. `IMappingObject` `ToValue<T>(bool autoInitialize = false)` method was not a clear method in purpose. 

Renamed method to `BuildValue<T>`.


* What has changed?
  * `ToValue<T>(bool autoInitialize = false)` renamed to `BuildValue<T>()` in `IMappingObject` and `MappingObject`.

Related issues?    
Resolves #21 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes   
