### PR TITLE
Feature/context detain

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,15 @@ The [`IContext`](#IContext) should also have an [IInjector](#IInjector) that it 
 
 Every [`IContext`](#IContext) should provide `event` callbacks to certain parts of its [`Initialize`](#Initalize) method. This will allow you to have more control over your [`Context`](#IContext).
 
+Every [`IContext`](#IContext) should also provide `Detain` and `Release` methods that should primarily be used to avoid an object being Garbage Collected pre-maturely when its scope has been left. This has a super niche use case so make sure it's required when using, otherwise you may cause unneccessary memory buildup.
+
 #### Context
 
 The standard TinYard implementation of [`IContext`](#IContext).
 
 [`Context`](#Context) provides basic implementations of the [`IContext`](#IContext) interface, and does nothing too fancy.
+
+The [`Context`](#Context) class implements `Detain` and `Release` methods by simply tracking them in a `HashSet<object>` that keeps them in memory.
 
 ##### Construction
 

--- a/TinYard.Tests/Tests/ContextTests.cs
+++ b/TinYard.Tests/Tests/ContextTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Exceptions;
@@ -161,6 +162,58 @@ namespace TinYard.Tests
 
             Assert.IsTrue(preInjectValue != postInjectValue);
             Assert.AreEqual(testValue, postInjectValue);
+        }
+
+        [TestMethod]
+        public void Context_Detains_Successfully()
+        {
+            _context.Initialize();
+
+            WeakReference reference = new WeakReference(null);
+
+            //Run action to create reference
+            new Action(() =>
+           {
+               object detainableObj = new object();
+
+               reference = new WeakReference(detainableObj, true);
+
+               _context.Detain(detainableObj);
+           })();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsNotNull(reference.Target);
+        }
+
+        [TestMethod]
+        public void Context_Releases_Successfully()
+        {
+            _context.Initialize();
+
+            WeakReference reference = new WeakReference(null);
+
+            new Action(() =>
+            {
+                object detainableObj = new object();
+
+                reference = new WeakReference(detainableObj, true);
+
+                _context.Detain(detainableObj);
+
+            })();
+
+            new Action(() =>
+           {
+                Assert.IsNotNull(reference.Target);
+               _context.Release(reference.Target);
+           })();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsNull(reference.Target);
         }
     }
 }

--- a/TinYard/Framework/API/Interfaces/IContext.cs
+++ b/TinYard/Framework/API/Interfaces/IContext.cs
@@ -24,5 +24,8 @@ namespace TinYard.API.Interfaces
 
         bool ContainsExtension(IExtension extension);
         bool ContainsExtension<T>() where T : IExtension;
+
+        void Detain(object objToDetain);
+        void Release(object objToRelease);
     }
 }

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -40,6 +40,8 @@ namespace TinYard
         private List<IConfig> _configsToInstall;
         private HashSet<IConfig> _configsInstalled;
 
+        private HashSet<object> _detainedObjs;
+
         private bool _initialized = false;
 
         public Context()
@@ -47,6 +49,8 @@ namespace TinYard
             _bundlesToInstall = new List<IBundle>();
             _extensionsToInstall = new List<IExtension>();
             _configsToInstall = new List<IConfig>();
+
+            _detainedObjs = new HashSet<object>();
 
             //Create our mapper, then add a hook so that we can inject into anything that gets mapped
             _mapper = new ValueMapper();
@@ -126,6 +130,17 @@ namespace TinYard
             _initialized = true;
 
             PostInitialize?.Invoke();
+        }
+
+        public void Detain(object objToDetain)
+        {
+            _detainedObjs.Add(objToDetain);
+        }
+
+        public void Release(object objToRelease)
+        {
+            if(_detainedObjs.Contains(objToRelease))
+                _detainedObjs.Remove(objToRelease);
         }
 
         private void InstallBundles()


### PR DESCRIPTION
You can now `Detain` and `Release` objects with the `IContext`. This allows you to hold an object off of Garbage Collection so that it can be used in a later scope.

* What is new?
  * `IContext.Detain(object objectToDetain)`
  * `IContext.Release(object objectToRelease)`
* What has changed?
  * `Context` class implements these methods. Uses a `HashSet<object>` to keep reference to them.
  * `ContextTests.cs` has relevant tests in it.

Related issues?    
Resolves #48 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes

**Should know about**    
Is there anything else that should be known?      
Any deployment notes?    
Any additional documentation?    
