### PR TITLE
Feature/mediator interface tests

### DIFF
--- a/TinYard.Tests/TestClasses/ITestView.cs
+++ b/TinYard.Tests/TestClasses/ITestView.cs
@@ -1,0 +1,6 @@
+﻿namespace TinYard.Tests.TestClasses
+{
+    public interface ITestView
+    {
+    }
+}

--- a/TinYard.Tests/TestClasses/InterfaceTestMediator.cs
+++ b/TinYard.Tests/TestClasses/InterfaceTestMediator.cs
@@ -1,0 +1,17 @@
+﻿using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Extensions.MediatorMap.API.Base;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class InterfaceTestMediator : Mediator
+    {
+        [Inject]
+        public ITestView view;
+
+        public override void Configure()
+        {
+            AddViewListener(TestEvent.Type.Test1, () => Dispatch(new TestEvent(TestEvent.Type.Test2)));
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestView.cs
+++ b/TinYard.Tests/TestClasses/TestView.cs
@@ -1,8 +1,9 @@
 ﻿using TinYard.Extensions.ViewController.Impl.Base;
+using TinYard.Tests.TestClasses;
 
 namespace TinYard.Extensions.ViewController.Tests.MockClasses
 {
-    public class TestView : View
+    public class TestView : View, ITestView
     {
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -1,14 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Runtime.InteropServices;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
 using TinYard.Extensions.MediatorMap.Impl.Mappers;
-using TinYard.Extensions.MediatorMap.Impl.VO;
 using TinYard.Extensions.ViewController;
 using TinYard.Extensions.ViewController.API.Interfaces;
-using TinYard.Extensions.ViewController.Impl.Base;
 using TinYard.Extensions.ViewController.Tests.MockClasses;
 using TinYard.Tests.TestClasses;
 
@@ -76,6 +73,37 @@ namespace TinYard.Extensions.MediatorMap.Tests
             _mapper.Map<TestView>().ToMediator<TestMediator>();
 
             TestView view = new TestView();
+        }
+
+        [TestMethod]
+        public void Mediator_Can_Map_To_Interface()
+        {
+            _mapper.Map<ITestView>().ToMediator<InterfaceTestMediator>();
+
+            //ViewRegister would potentially cause this next line to throw if the mapping wasn't correct
+            var testView = new TestView();
+        }
+
+        [TestMethod]
+        public void Mediator_Works_On_Interface_Mapping()
+        {
+            _mapper.Map<ITestView>().ToMediator<InterfaceTestMediator>();
+
+            var testView = new TestView();
+
+            var dispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>() as IEventDispatcher;
+
+            bool listenerInvoked = false;
+            dispatcher.AddListener<TestEvent>(TestEvent.Type.Test2, (evt) =>
+            {
+                listenerInvoked = true;
+            });
+
+
+            //Mediator has a listener on view for test 1, and dispatches test 2 when heard
+            testView.Dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            Assert.IsTrue(listenerInvoked);
         }
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -10,14 +10,15 @@ namespace TinYard.Extensions.MediatorMap.API.Interfaces
         event Action<IMediatorMappingObject> OnMediatorMapping;
         IMediatorFactory MediatorFactory { get; }
 
-        IMediatorMappingObject Map<T>() where T : IView;
+        IMediatorMappingObject Map<T>();
         IMediatorMappingObject Map(IView view);
+        IMediatorMappingObject Map(object view);
 
-        IMediatorMappingObject GetMapping<T>() where T : IView;
+        IMediatorMappingObject GetMapping<T>();
         IMediatorMappingObject GetMapping(IView type);
         IReadOnlyList<IMediatorMappingObject> GetAllMappings();
 
-        object GetMappingMediator<T>() where T : IView;
+        object GetMappingMediator<T>();
         object GetMappingMediator(IView type);
     }
 }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMappingObject.cs
@@ -13,8 +13,9 @@ namespace TinYard.Extensions.MediatorMap.API.VO
 
         event Action<IMediatorMappingObject> OnMediatorMapped;
 
-        IMediatorMappingObject Map<T>() where T : IView;
+        IMediatorMappingObject Map<T>();
         IMediatorMappingObject Map(IView view);
+        IMediatorMappingObject Map(object view);
 
         IMediatorMappingObject ToMediator<T>() where T : IMediator;
         IMediatorMappingObject ToMediator(IMediator mediator);

--- a/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
+++ b/TinYard/Extensions/MediatorMap/Impl/VO/MediatorMappingObject.cs
@@ -16,7 +16,7 @@ namespace TinYard.Extensions.MediatorMap.Impl.VO
 
         public event Action<IMediatorMappingObject> OnMediatorMapped;
 
-        public IMediatorMappingObject Map<T>() where T : IView
+        public IMediatorMappingObject Map<T>()
         {
             ViewType = typeof(T);
 
@@ -26,6 +26,24 @@ namespace TinYard.Extensions.MediatorMap.Impl.VO
         public IMediatorMappingObject Map(IView view)
         {
             View = view;
+            ViewType = view.GetType();
+
+            return this;
+        }
+
+        public IMediatorMappingObject Map(object view)
+        {
+            Type viewType = view.GetType();
+
+            if(viewType.IsInterface)
+            {
+                if (!typeof(IView).IsAssignableFrom(viewType))
+                    return this;
+            }
+            else if (!typeof(IView).IsAssignableFrom(viewType))
+                return this;
+
+            View = view as IView;
             ViewType = view.GetType();
 
             return this;


### PR DESCRIPTION
This feature branch brings with it the ability to map an `interface` to a `Mediator`. Previously you could only map types of `IView`.

* What is new?
  * Added tests to ensure this works as intended
  * Added a `Map(object view)` method to `IMediatorMapper` and `MediatorMapper`
  * Added a `Map(object view)` method to `IMediatorMappingObject` and `MediatorMappingObject`
* What has changed?
  * Changed the `IMediatorMapper` interface to allow `Map<T>` to not be Type constrained. Updated on `MediatorMapper` also.
  * Changed the `IMediatorMappingObject` interface to allow `Map<T>` to not be Type constrained. Updated on `MediatorMappingObject` also.

Related issues?    
Resolves #54 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes