### PR TITLE
Feature/unique mediators

### DIFF
--- a/TinYard.Tests/TestClasses/TestMediator.cs
+++ b/TinYard.Tests/TestClasses/TestMediator.cs
@@ -16,6 +16,8 @@ namespace TinYard.Tests.TestClasses
 
         public override void Configure()
         {
+            AddViewListener(TestEvent.Type.Test1, () => Dispatch(new TestEvent(TestEvent.Type.Test2)));
+
             AddViewListener(TestEvent.Type.Test1, () => OnViewEventHeard?.Invoke());
 
             AddContextListener(TestEvent.Type.Test1, () => OnContextEventHeard?.Invoke());

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -105,5 +105,29 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
             Assert.IsTrue(listenerInvoked);
         }
+
+        [TestMethod]
+        public void Mapper_Creates_Unique_Mediator_Per_View()
+        {
+            var dispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>() as IEventDispatcher;
+
+            _mapper.Map<TestView>().ToMediator<TestMediator>();
+
+            int numberOfEventInvokes = 0;
+            dispatcher.AddListener<TestEvent>(TestEvent.Type.Test2, (evt) =>
+            {
+                numberOfEventInvokes++;
+            });
+
+
+            int numberOfViews = 2;
+            for(int i = 0; i < numberOfViews; i++)
+            {
+                //Mediator has a listener on view for test 1 event, and dispatches test 2 event when heard
+                new TestView().Dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+            }
+
+            Assert.IsTrue(numberOfEventInvokes == numberOfViews);
+        }
     }
 }


### PR DESCRIPTION
This merge requests brings a new test for the `MediatorMapper`. It tests that each `View` gets its own unique `Mediator` when `Registered`.

* What is new?
  * New test case in `MediatorMapperTests`
* What has changed?
  * Modified `TestMediator` class to make this test easy to check.

Related issues?    
Resolves #55 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes