### PR TITLE
Feature/ Command Guards

### DIFF
--- a/TinYard.Tests/TestClasses/TestGuard.cs
+++ b/TinYard.Tests/TestClasses/TestGuard.cs
@@ -1,0 +1,16 @@
+﻿using TinYard.Framework.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class TestGuard : IGuard
+    {
+        [Inject]
+        public object Injectable;
+
+        public bool Satisfies()
+        {
+            return Injectable != null;
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestGuard.cs
+++ b/TinYard.Tests/TestClasses/TestGuard.cs
@@ -1,14 +1,14 @@
-﻿using TinYard.Framework.API.Interfaces;
+﻿using TinYard.Framework.API.Base;
 using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Tests.TestClasses
 {
-    public class TestGuard : IGuard
+    public class TestGuard : Guard
     {
         [Inject]
         public object Injectable;
 
-        public bool Satisfies()
+        public override bool Satisfies()
         {
             return Injectable != null;
         }

--- a/TinYard.Tests/TestClasses/TestGuardedCommand.cs
+++ b/TinYard.Tests/TestClasses/TestGuardedCommand.cs
@@ -1,0 +1,14 @@
+﻿using TinYard.Extensions.CommandSystem.API.Interfaces;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class TestGuardedCommand : ICommand
+    {
+        public static bool ExecuteCalled = false;
+
+        public void Execute()
+        {
+            ExecuteCalled = true;
+        }
+    }
+}

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -45,8 +45,6 @@ namespace TinYard.Tests
 
             _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
 
-            Assert.IsFalse(TestCommand.ExecuteCalled);
-
             _eventDispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
 
             Assert.IsFalse(TestCommand.ExecuteCalled);

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CommandSystem;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Extensions.CommandSystem.Impl.CommandMaps;
+using TinYard.Extensions.EventSystem.Tests.MockClasses;
+using TinYard.Framework.API.Interfaces;
+using TinYard.Impl.Mappers;
+using TinYard.Tests.TestClasses;
+
+namespace TinYard.Tests
+{
+    [TestClass]
+    public class GuardTests
+    {
+        private IContext _context;
+        private ICommandMap _commandMap;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context.Install(new CommandSystemExtension());
+            _context.Initialize();
+
+            _commandMap = _context.Mapper.GetMappingValue<ICommandMap>() as ICommandMap;
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _context = null;
+            _commandMap = null;
+        }
+
+        [TestMethod]
+        public void Guard_Can_Be_Added_To_Command()
+        {
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
+        }
+    }
+}

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -1,12 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.CommandSystem;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
-using TinYard.Extensions.CommandSystem.Impl.CommandMaps;
+using TinYard.Extensions.EventSystem;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
-using TinYard.Framework.API.Interfaces;
-using TinYard.Impl.Mappers;
 using TinYard.Tests.TestClasses;
 
 namespace TinYard.Tests
@@ -20,10 +17,7 @@ namespace TinYard.Tests
         [TestInitialize]
         public void Setup()
         {
-            _context.Install(new CommandSystemExtension());
-            _context.Initialize();
-
-            _commandMap = _context.Mapper.GetMappingValue<ICommandMap>() as ICommandMap;
+            _context = new Context();
         }
 
         [TestCleanup]
@@ -36,6 +30,12 @@ namespace TinYard.Tests
         [TestMethod]
         public void Guard_Can_Be_Added_To_Command()
         {
+            _context.Install(new EventSystemExtension());
+            _context.Install(new CommandSystemExtension());
+            _context.Initialize();
+
+            _commandMap = _context.Mapper.GetMappingValue<ICommandMap>() as ICommandMap;
+
             _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
         }
     }

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.CommandSystem;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem;
+using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Tests.TestClasses;
 
@@ -13,6 +15,7 @@ namespace TinYard.Tests
     {
         private IContext _context;
         private ICommandMap _commandMap;
+        private IEventDispatcher _eventDispatcher;
 
         [TestInitialize]
         public void Setup()
@@ -30,13 +33,33 @@ namespace TinYard.Tests
         [TestMethod]
         public void Guard_Can_Be_Added_To_Command()
         {
+            SetupCommandExtension();
+
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
+        }
+
+        [TestMethod]
+        public void Command_Doesnt_Run_If_Guard_Not_Satisfied()
+        {
+            SetupCommandExtension();
+
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
+
+            Assert.IsFalse(TestCommand.ExecuteCalled);
+
+            _eventDispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            Assert.IsFalse(TestCommand.ExecuteCalled);
+        }
+
+        private void SetupCommandExtension()
+        {
             _context.Install(new EventSystemExtension());
             _context.Install(new CommandSystemExtension());
             _context.Initialize();
 
             _commandMap = _context.Mapper.GetMappingValue<ICommandMap>() as ICommandMap;
-
-            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
+            _eventDispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>() as IEventDispatcher;
         }
     }
 }

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -43,11 +43,25 @@ namespace TinYard.Tests
         {
             SetupCommandExtension();
 
-            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestCommand>().WithGuard<TestGuard>();
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestGuardedCommand>().WithGuard<TestGuard>();
 
             _eventDispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
 
-            Assert.IsFalse(TestCommand.ExecuteCalled);
+            Assert.IsFalse(TestGuardedCommand.ExecuteCalled);
+        }
+
+        [TestMethod]
+        public void Command_Runs_When_Guard_Satisfied()
+        {
+            SetupCommandExtension();
+
+            _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestGuardedCommand>().WithGuard<TestGuard>();
+
+            _context.Mapper.Map<object>().ToValue(new object());
+
+            _eventDispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            Assert.IsTrue(TestGuardedCommand.ExecuteCalled);
         }
 
         private void SetupCommandExtension()

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Framework.API.Base;
 using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem.API.Interfaces
@@ -12,12 +13,12 @@ namespace TinYard.Extensions.CommandSystem.API.Interfaces
 
         Type Command { get; }
 
-        IReadOnlyList<IGuard> Guards { get; }
+        IReadOnlyList<Type> GuardTypes { get; }
 
         ICommandMapping Map<T>(Enum type = null) where T : IEvent;
 
         ICommandMapping ToCommand<T>() where T : ICommand;
 
-        ICommandMapping WithGuard<T>() where T : IGuard;
+        ICommandMapping WithGuard<T>() where T : Guard;
     }
 }

--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem.API.Interfaces
 {
@@ -10,8 +12,12 @@ namespace TinYard.Extensions.CommandSystem.API.Interfaces
 
         Type Command { get; }
 
+        IReadOnlyList<IGuard> Guards { get; }
+
         ICommandMapping Map<T>(Enum type = null) where T : IEvent;
 
         ICommandMapping ToCommand<T>() where T : ICommand;
+
+        ICommandMapping WithGuard<T>() where T : IGuard;
     }
 }

--- a/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/CommandMaps/EventCommandMap.cs
@@ -5,11 +5,15 @@ using TinYard.Extensions.CommandSystem.Impl.Factories;
 using TinYard.Extensions.CommandSystem.Impl.VO;
 using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.CommandSystem.Impl.CommandMaps
 {
     public class EventCommandMap : ICommandMap
     {
+        [Inject]
+        public IGuardFactory GuardFactory;
+
         private IEventDispatcher _eventDispatcher;
         private IInjector _injector;
 
@@ -57,6 +61,17 @@ namespace TinYard.Extensions.CommandSystem.Impl.CommandMaps
         {
             if (mapping.Command == null)
                 return;
+
+            var guardTypes = mapping.GuardTypes;
+
+            foreach(Type guardType in guardTypes)
+            {
+                var guard = GuardFactory.Build(guardType);
+                _injector.Inject(guard);
+
+                if (!guard.Satisfies())
+                    return;
+            }
 
             //Should be injected into in the Factory
             ICommand builtCommand = _commandFactory.Build(mapping.Command, evt);

--- a/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Framework.API.Base;
 using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem.Impl.VO
@@ -14,9 +15,9 @@ namespace TinYard.Extensions.CommandSystem.Impl.VO
 
         public Type Command { get; private set; }
 
-        public IReadOnlyList<IGuard> Guards { get { return _guards.AsReadOnly(); } }
+        public IReadOnlyList<Type> GuardTypes { get { return _guardTypes.AsReadOnly(); } }
 
-        private List<IGuard> _guards = new List<IGuard>();
+        private List<Type> _guardTypes = new List<Type>();
 
         public ICommandMapping Map<T>(Enum type = null) where T : IEvent
         {
@@ -33,9 +34,11 @@ namespace TinYard.Extensions.CommandSystem.Impl.VO
             return this;
         }
 
-        public ICommandMapping WithGuard<T>() where T : IGuard
+        public ICommandMapping WithGuard<T>() where T : Guard
         {
-            throw new NotImplementedException();
+            _guardTypes.Add(typeof(T));
+
+            return this;
         }
     }
 }

--- a/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
 
 namespace TinYard.Extensions.CommandSystem.Impl.VO
 {
@@ -11,6 +13,10 @@ namespace TinYard.Extensions.CommandSystem.Impl.VO
         public Enum EventType { get; private set; }
 
         public Type Command { get; private set; }
+
+        public IReadOnlyList<IGuard> Guards { get { return _guards.AsReadOnly(); } }
+
+        private List<IGuard> _guards = new List<IGuard>();
 
         public ICommandMapping Map<T>(Enum type = null) where T : IEvent
         {
@@ -25,6 +31,11 @@ namespace TinYard.Extensions.CommandSystem.Impl.VO
             Command = typeof(T);
 
             return this;
+        }
+
+        public ICommandMapping WithGuard<T>() where T : IGuard
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/TinYard/Framework/API/Base/Guard.cs
+++ b/TinYard/Framework/API/Base/Guard.cs
@@ -1,0 +1,13 @@
+﻿using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Framework.API.Base
+{
+    public abstract class Guard : IGuard
+    {
+        public Guard() 
+        {
+        }
+
+        public abstract bool Satisfies();
+    }
+}

--- a/TinYard/Framework/API/Interfaces/IGuard.cs
+++ b/TinYard/Framework/API/Interfaces/IGuard.cs
@@ -1,0 +1,7 @@
+﻿namespace TinYard.Framework.API.Interfaces
+{
+    public interface IGuard
+    {
+        bool Satisfies();
+    }
+}

--- a/TinYard/Framework/API/Interfaces/IGuardFactory.cs
+++ b/TinYard/Framework/API/Interfaces/IGuardFactory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using TinYard.Framework.API.Base;
+
+namespace TinYard.Framework.API.Interfaces
+{
+    public interface IGuardFactory : IFactory
+    {
+        IGuard Build<T>() where T : Guard;
+        IGuard Build(Type guardType);
+    }
+}

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
+using TinYard.Framework.Impl.Factories;
 using TinYard.Framework.Impl.Injectors;
 using TinYard.Impl.Exceptions;
 using TinYard.Impl.Mappers;
@@ -62,6 +63,9 @@ namespace TinYard
             _mapper.Map<IContext>().ToValue(this);
             _mapper.Map<IMapper>().ToValue(_mapper);
             _mapper.Map<IInjector>().ToValue(_injector);
+
+
+            _mapper.Map<IGuardFactory>().ToValue(new GuardFactory());
         }
 
         public IContext Install(IExtension extension)

--- a/TinYard/Framework/Impl/Factories/GuardFactory.cs
+++ b/TinYard/Framework/Impl/Factories/GuardFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using TinYard.Framework.API.Base;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Framework.Impl.Factories
+{
+    public class GuardFactory : IGuardFactory
+    {
+        public object Build(params object[] args)
+        {
+            List<IGuard> builtGuards = new List<IGuard>();
+
+            foreach(object argument in args)
+            {
+                if (argument is Guard)
+                    builtGuards.Add(Build(argument.GetType());
+            }
+
+            return builtGuards;
+        }
+
+        public IGuard Build<T>() where T : Guard
+        {
+            return Build(typeof(T));
+        }
+
+        public IGuard Build(Type guardType)
+        {
+            //Must be type of Guard
+            if (!guardType.IsAssignableFrom(typeof(Guard)))
+                return null;
+
+            return Activator.CreateInstance(guardType) as IGuard;
+        }
+    }
+}

--- a/TinYard/Framework/Impl/Factories/GuardFactory.cs
+++ b/TinYard/Framework/Impl/Factories/GuardFactory.cs
@@ -14,7 +14,7 @@ namespace TinYard.Framework.Impl.Factories
             foreach(object argument in args)
             {
                 if (argument is Guard)
-                    builtGuards.Add(Build(argument.GetType());
+                    builtGuards.Add(Build(argument.GetType()));
             }
 
             return builtGuards;
@@ -28,7 +28,7 @@ namespace TinYard.Framework.Impl.Factories
         public IGuard Build(Type guardType)
         {
             //Must be type of Guard
-            if (!guardType.IsAssignableFrom(typeof(Guard)))
+            if (!typeof(Guard).IsAssignableFrom(guardType))
                 return null;
 
             return Activator.CreateInstance(guardType) as IGuard;


### PR DESCRIPTION
Command Guards!
 
Stop your command from executing when those conditions _aren't quite right_.

* What is new?
  * Added the `IGuard` interface.
  * Added the base abstract `Guard` class.
  * Added the `IGuardFactory` interface.
  * Added the `GuardFactory` class. One of these is created in the `Context` constructor, which is then mapped to `IGuardFactory`.

* What has changed?
  * `ICommandMapping` interface now has a `WithGuard<T> where T : Guard` method/
  * `ICommandMapping` interface also has a `IReadOnlyList<Type>` that contains all the `Guard` types related to the `CommandMapping`.
  * `EventCommandMap` builds any/all `Guard`'s related to the `ICommandMapping`, `injects` into them and ensures they are `satisfied` before building and running the related `ICommand`.

Related issues?    
Resolves #53 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes