### PR TITLE
Fix/multiple mediators to a view

### DIFF
--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -129,5 +129,27 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
             Assert.IsTrue(numberOfEventInvokes == numberOfViews);
         }
+
+        [TestMethod]
+        public void Mapper_Creates_All_Mapped_Mediators_To_View()
+        {
+            var dispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>() as IEventDispatcher;
+
+            int expectedNumberOfInvokes = 2;
+            _mapper.Map<TestView>().ToMediator<TestMediator>();
+            _mapper.Map<TestView>().ToMediator<InterfaceTestMediator>();
+
+            int numberOfEventInvokes = 0;
+            dispatcher.AddListener<TestEvent>(TestEvent.Type.Test2, (evt) =>
+            {
+                numberOfEventInvokes++;
+            });
+
+            var view = new TestView();
+            view.Dispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
+
+            //We would expect these to be equal, if both mapped mediators were created
+            Assert.AreEqual(expectedNumberOfInvokes, numberOfEventInvokes);
+        }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.EventSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
@@ -50,7 +51,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
             var expected = new TestMediator();
             _mapper.Map(view).ToMediator(expected);
 
-            var actual = _mapper.GetMapping<TestView>().Mediator;
+            var actual = _mapper.GetMappings<TestView>().ToArray()[0].Mediator;
 
             Assert.AreEqual(expected, actual);
         }
@@ -62,7 +63,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
             var expected = _mapper.Map<TestView>().ToMediator(mediator);
 
-            var actual = _mapper.GetMapping<TestView>();
+            var actual = _mapper.GetMappings<TestView>().ToArray()[0];
 
             Assert.AreEqual(expected, actual);
         }

--- a/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
+++ b/TinYard/Extensions/MediatorMap/API/Interfaces/IMediatorMapper.cs
@@ -14,11 +14,8 @@ namespace TinYard.Extensions.MediatorMap.API.Interfaces
         IMediatorMappingObject Map(IView view);
         IMediatorMappingObject Map(object view);
 
-        IMediatorMappingObject GetMapping<T>();
-        IMediatorMappingObject GetMapping(IView type);
+        IEnumerable<IMediatorMappingObject> GetMappings<T>();
+        IEnumerable<IMediatorMappingObject> GetMappings(IView type);
         IReadOnlyList<IMediatorMappingObject> GetAllMappings();
-
-        object GetMappingMediator<T>();
-        object GetMappingMediator(IView type);
     }
 }

--- a/TinYard/TinYard.csproj
+++ b/TinYard/TinYard.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/TinYard/TinYard</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <PackageTags>C#, dll, framework, DI, Events, Dependency Injection, IoC, Commands</PackageTags>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0</Version>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/TinYard/TinYard.csproj
+++ b/TinYard/TinYard.csproj
@@ -9,9 +9,9 @@
     <RepositoryUrl>https://github.com/TinYard/TinYard</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <PackageTags>C#, dll, framework, DI, Events, Dependency Injection, IoC, Commands</PackageTags>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
-    <Version>1.1.1</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Modified how the `MediatorMapper` handles `Mapping`s. It now gets _all_ `Mapping`s for a `View` type, and creates all the `Mediator`s related when needed.

* What has changed?
  * `IMediatorMapper` changed `GetMapping` functions to `GetMappings`. Changed the return type to `IEnumerable<IMediatorMappingObject` from `IMediatorMappingObject`. This is because there's potentially multiple `Mapping`s and we want to ensure you get them all.
  * `MediatorMapper` impl updated to reflect interface changes.
  * `MediatorMapper` now checks for _all_ `Mapping`s for a `View` and creates and configures each `Mediator` that is needed for the `View` when it registers itself.
  * Updated Test cases to reflect other changes.
  * `GetMappingMediator` methods removed. We potentially will have multiple `Mapping`s for a `View` so we don't know which one is wanted. Better off leaving the User to use `GetMappings` for their `View` and decide themself.

Related issues?    
Resolves #60 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes