### PR TITLE
Fix/inject into injectables

### DIFF
--- a/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
@@ -1,0 +1,10 @@
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard_Tests.TestClasses
+{
+    public class TestSecondaryInjectable
+    {
+        [Inject]
+        public TestInjectable InjectedValue;
+    }
+}

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -81,5 +81,24 @@ namespace TinYard.Tests
 
             Assert.AreEqual(expected, injectable.Value);
         }
+
+        [TestMethod]
+        public void Injector_Injects_Into_Injectable_Values()
+        {
+            TestInjectable injectable = new TestInjectable();
+            _context.Mapper.Map<TestInjectable>().ToValue(injectable);
+
+            //Making sure it's not been set somehow by accident
+            Assert.AreEqual(default(int), injectable.Value);
+
+            //Map an int so that when we call `Inject` on a class that needs a `TestInjectable`, 
+            //it can Inject this int into the `TestInjectable` value
+            int expected = 5;
+            _context.Mapper.Map<int>().ToValue(expected);
+
+            _injector.Inject(new TestSecondaryInjectable());
+
+            Assert.AreEqual(expected, injectable.Value);
+        }
     }
 }

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -39,11 +39,16 @@ namespace TinYard.Framework.Impl.Injectors
                 Type fieldType = field.FieldType;
                 if(_mapper.GetMapping(fieldType) != null)
                 {
+                    var valueToInject = _mapper.GetMappingValue(fieldType);
+                    Inject(valueToInject);
+
                     field.SetValue(classToInjectInto, _mapper.GetMappingValue(fieldType));
                 }
                 else if(_extraInjectables.ContainsKey(fieldType))
                 {
-                    field.SetValue(classToInjectInto, _extraInjectables[fieldType]);
+                    var valueToInject = _extraInjectables[fieldType];
+                    Inject(valueToInject);
+                    field.SetValue(classToInjectInto, valueToInject);
                 }
             }
         }


### PR DESCRIPTION
Fix the bug where the `TinYardInjector` didn't ensure any Values being injected into another class were in a ready state in terms of also being fully injected into.

* What is new?
  * Added a new Test class called `TestSecondaryInjectable` that simply asks for a `TestInjectable` class to be injected into.
* What has changed?
  * `TinYardInjector` now calls `Inject` on every value it takes from the `IMapper` to ensure it's injecting useful values.
  * Added `Injector_Injects_Into_Injectable_Values` test case to `InjectorTests`.

Related issues?    
Resolves #66 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes
