### PR TITLE
Feature/callback timer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,92 @@ Before any [`Command`](#ICommand) is executed, the [`ICommandMapping`](#ICommand
 
 [`CommandMapping`](#CommandMapping) is the base impl of [`ICommandMapping`](#ICommandMapping) and is also a spin on [`MappingObject`](#MappingObject).
 
+## Callback Timer Extension
+
+### Dependencies
+
+The [Callback Timer Extension](#Callback-Timer-Extension) is depdendant on:
+
+* [Event System Extension](#Event-System-Extension)
+* [Command System Extension](#Command-System-Extension)
+
+### About the Extension
+
+The [Callback Timer Extension](#Callback-Timer-Extension) provides you the ability to easily invoke any Action in any amount of time from now.
+
+Need to dispatch an event in 5 seconds? Use the [`ICallbackTimer`](#ICallback-Timer) instead of writing some messy get around.
+
+To use the [`ICallbackTimer`](#ICallback-Timer) you can inject it into your anything, or use the new events provided.
+
+#### Extension and Configurations
+
+To install the [Callback Timer Extension](#Callback-Timer-Extension), install the [`CallbackTimerExtension`](#Callback-Timer-Extension) class into your [Context](#IContext).
+
+No configurations are available for the [Callback Timer Extension](#Callback-Timer-Extension).
+
+## ICallback Timer
+
+The [`ICallbackTimer`](#ICallback-Timer) interface is the bread-and-butter of this extension for the user. You should `inject` the [`ICallbackTimer`](#ICallback-Timer) when wanting to make use of the `extension`, or use the `event`s found further below.
+
+This interface has only a few functions: 
+
+```c#
+void AddTimer(int ticks, Action callback)
+void AddTimer(double seconds, Action callback)
+
+bool RemoveTimer(Action callback)
+```
+
+## Events
+
+In the [Callback Timer Extension](#Callback-Timer-Extension) there are two `event`s that can be utilised to save you from needing to inject the [`ICallbackTimer`](#ICallback-Timer).
+
+These are:    
+[`AddCallbackTimerEvent`](#Add-Event),    
+[`RemoveCallbackTimerEvent`](#Remove-Event)
+
+### Add Event
+
+The [`AddCallbackTimerEvent`](#Add-Event) has two constructors; one allows you to specify the [`Timer`](#Timer) duration in `tick`s and the other allows you to specify the duration in  seconds.
+
+The length of a `tick` is determined by the `System.Diagnostics.Stopwatch.Frequency` property.
+
+### Remove Event
+
+The [`RemoveCallbackTimerEvent`](#Remove-Event) has only one constructor:
+`RemoveCallbackTimerEvent(Type type, Action callbackToRemove)`.
+
+This seems pretty self-explanatory. Pass in the same callback as what was added, and it will remove any timers with that callback.
+
+## Commands
+
+There are, like the events, only two commands in the [`Callback Timer Extension`](#Callback-Timer-Extension).
+
+[`AddCallbackTimerCommand`](#Add-Command)
+[`RemoveCallbackTimerCommand`](#Remove-Command)
+
+### Add Command
+
+The [`AddCallbackTimerCommand`](#Add-Command) has the [`ICallbackTimer`](#ICallback-Timer) injected, and simply calls the `AddTimer` function with the callback and duration provided from the `event`.
+
+### Remove Command
+
+The [`RemoveCallbackTimerCommand`](#Remove-Command) has an even easier job than the [`AddCallbackTimerCommand`](#Add-Command) - It is setup the same, but just has to call `RemoveTimer` on the [`ICallbackTimer`](#ICallback-Timer) with the provided callback.
+
+## Callback Timer Service
+
+The [`CallbackTimerService`](#Callback-Timer-Service) class is the meat of the `extension`. This class inherits the [`ICallbackTimer`](#ICallback Timer) interface and implements it - it is then `mapped` onto the `context` by the `extension` under the interface.
+
+Upon construction, the [`CallbackTimerService`] starts a `Task` that is an Update loop - A never ending loop that will each loop call `UpdateTimers`, which in turn calls `Update` on each [`Timer`](#Timer).
+
+Each loop has a small amount of time between it, known as `delta time`. This is passed onto the [`Timer`](#Timer)'s so that they can internally update their time tracking. `delta time` is determined by using a `System.Diagnostics.Stopwatch` and recording the time between each loop.
+
+## Timer
+
+The [`Timer`](#Timer) VO class is a simple class that makes keeping track of callbacks easier for the [`CallbackTimerService`](#CallbackTimerService). 
+
+The main functionality of the class is in the `Update` function that increments the `CurrentLifetime` property. Once `CurrentLifetime` is bigger or equal to the `TimerDuration` property, the `TimerCallback` action is invoked. 
+
 ---
 
 ## TinYard Bundles

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerEventsTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerEventsTests.cs
@@ -60,5 +60,29 @@ namespace TinYard.Extensions.CallbackTimer.Tests
 
             Assert.IsTrue(invoked);
         }
+
+        [TestMethod]
+        public void Can_Remove_Timer_Through_Events()
+        {
+            _contextEventDispatcher.Dispatch(new RemoveCallbackTimerEvent(RemoveCallbackTimerEvent.Type.Remove, () => { }));
+        }
+
+        [TestMethod]
+        public void Event_Removed_Timer_Is_Removed()
+        {
+            bool invoked = false;
+            Action callback = () =>
+            {
+                invoked = true;
+            };
+
+            _callbackTimer.AddTimer(100d, callback);
+
+            _contextEventDispatcher.Dispatch(new RemoveCallbackTimerEvent(RemoveCallbackTimerEvent.Type.Remove, callback));
+
+            _callbackTimer.UpdateTimers(100d);
+
+            Assert.IsFalse(invoked);
+        }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerEventsTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerEventsTests.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CallbackTimer;
+using TinYard.Extensions.CallbackTimer.API.Events;
+using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CallbackTimer.Impl.Services;
+using TinYard.Extensions.CommandSystem;
+using TinYard.Extensions.EventSystem;
+using TinYard.Extensions.EventSystem.API.Interfaces;
+
+namespace TinYard.Extensions.CallbackTimer.Tests
+{
+    [TestClass]
+    public class CallbackTimerEventsTests
+    {
+        private IContext _context;
+        private IEventDispatcher _contextEventDispatcher;
+        private CallbackTimerService _callbackTimer;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context = new Context();
+            _context.Install(new EventSystemExtension());
+            _context.Install(new CommandSystemExtension());
+            _context.Install(new CallbackTimerExtension());
+
+            _context.Initialize();
+
+            _callbackTimer = _context.Mapper.GetMappingValue<ICallbackTimer>() as CallbackTimerService;
+            _contextEventDispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _context = null;
+            _callbackTimer = null;
+        }
+
+        [TestMethod]
+        public void Can_Add_Timer_Through_Events()
+        {
+            _contextEventDispatcher.Dispatch(new AddCallbackTimerEvent(AddCallbackTimerEvent.Type.Add, 0, () => { }));
+        }
+
+        [TestMethod]
+        public void Event_Added_Timer_Gets_Added_And_Invoked()
+        {
+            bool invoked = false;
+            Action callback = () =>
+            {
+                invoked = true;
+            };
+
+            _contextEventDispatcher.Dispatch(new AddCallbackTimerEvent(AddCallbackTimerEvent.Type.Add, 0d, callback));
+
+            _callbackTimer.UpdateTimers(0d);
+
+            Assert.IsTrue(invoked);
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerExtensionTests.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CallbackTimer.API.Services;
+
+namespace TinYard.Extensions.CallbackTimer.Tests
+{
+    [TestClass]
+    public class CallbackTimerExtensionTests
+    {
+        private CallbackTimerExtension _extension;
+        private IContext _context;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _extension = new CallbackTimerExtension();
+            _context = new Context();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _extension = null;
+            _context = null;
+        }
+
+        [TestMethod]
+        public void CallbackTimerExtension_Is_IExtension()
+        {
+            Assert.IsInstanceOfType(_extension, typeof(IExtension));
+        }
+
+        [TestMethod]
+        public void Context_Installs_Extension()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+        }
+
+        [TestMethod]
+        public void CallbackTimer_Is_Mapped()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+
+            Assert.IsNotNull(_context.Mapper.GetMappingValue<ICallbackTimer>());
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerExtensionTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CommandSystem;
+using TinYard.Extensions.EventSystem;
 
 namespace TinYard.Extensions.CallbackTimer.Tests
 {
@@ -14,7 +16,10 @@ namespace TinYard.Extensions.CallbackTimer.Tests
         public void Setup()
         {
             _extension = new CallbackTimerExtension();
+
             _context = new Context();
+            _context.Install(new EventSystemExtension());
+            _context.Install(new CommandSystemExtension());
         }
 
         [TestCleanup]

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CallbackTimer.Impl.Services;
 
 namespace TinYard.Extensions.CallbackTimer.Tests
 {
@@ -8,7 +9,7 @@ namespace TinYard.Extensions.CallbackTimer.Tests
     public class CallbackTimerTests
     {
         private IContext _context;
-        private ICallbackTimer _callbackTimer;
+        private CallbackTimerService _callbackTimer;
 
         [TestInitialize]
         public void Setup()
@@ -17,13 +18,14 @@ namespace TinYard.Extensions.CallbackTimer.Tests
             _context.Install(new CallbackTimerExtension());
             _context.Initialize();
 
-            _callbackTimer = _context.Mapper.GetMappingValue<ICallbackTimer>();
+            _callbackTimer = _context.Mapper.GetMappingValue<ICallbackTimer>() as CallbackTimerService;
         }
 
         [TestCleanup]
         public void Teardown()
         {
             _context = null;
+            _callbackTimer = null;
         }
 
         [TestMethod]
@@ -33,19 +35,25 @@ namespace TinYard.Extensions.CallbackTimer.Tests
         }
 
         [TestMethod]
-        public void Context_Installs_Extension()
+        public void CallbackTimer_Allows_Callback_Adding()
         {
-            _context.Install(_extension);
-            _context.Initialize();
+            _callbackTimer.AddTimer(0, () => { });
         }
 
         [TestMethod]
-        public void CallbackTimer_Is_Mapped()
+        public void CallbackTimer_Invokes_Callback()
         {
-            _context.Install(_extension);
-            _context.Initialize();
+            bool invoked = false;
 
-            Assert.IsNotNull(_context.Mapper.GetMappingValue<ICallbackTimer>());
+            _callbackTimer.AddTimer(0, () =>
+            {
+                invoked = true;
+            });
+
+            //So that we're not relying on System time and whatnot, invoke it directly
+            _callbackTimer.UpdateTimers(0d);
+
+            Assert.IsTrue(invoked);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using TinYard.Extensions.CallbackTimer.API.Services;
 using TinYard.Extensions.CallbackTimer.Impl.Services;
 
@@ -47,6 +48,24 @@ namespace TinYard.Extensions.CallbackTimer.Tests
             _callbackTimer.UpdateTimers(0d);
 
             Assert.IsTrue(invoked);
+        }
+
+        [TestMethod]
+        public void CallbackTimer_Allows_Callback_Removing()
+        {
+            bool invoked = false;
+
+            Action callback = () =>
+            {
+                invoked = true;
+            };
+
+            _callbackTimer.AddTimer(100d, callback);
+            _callbackTimer.RemoveTimer(callback);
+
+            _callbackTimer.UpdateTimers(100d);
+
+            Assert.IsFalse(invoked);
         }
     }
 }

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinYard.API.Interfaces;
+using TinYard.Extensions.CallbackTimer.API.Services;
+
+namespace TinYard.Extensions.CallbackTimer.Tests
+{
+    [TestClass]
+    public class CallbackTimerTests
+    {
+        private IContext _context;
+        private ICallbackTimer _callbackTimer;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context = new Context();
+            _context.Install(new CallbackTimerExtension());
+            _context.Initialize();
+
+            _callbackTimer = _context.Mapper.GetMappingValue<ICallbackTimer>();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _context = null;
+        }
+
+        [TestMethod]
+        public void CallbackTimer_Is_ICallbackTimer()
+        {
+            Assert.IsInstanceOfType(_callbackTimer, typeof(ICallbackTimer));
+        }
+
+        [TestMethod]
+        public void Context_Installs_Extension()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+        }
+
+        [TestMethod]
+        public void CallbackTimer_Is_Mapped()
+        {
+            _context.Install(_extension);
+            _context.Initialize();
+
+            Assert.IsNotNull(_context.Mapper.GetMappingValue<ICallbackTimer>());
+        }
+    }
+}

--- a/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CallbackTimer/CallbackTimerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TinYard.API.Interfaces;
 using TinYard.Extensions.CallbackTimer.API.Services;
 using TinYard.Extensions.CallbackTimer.Impl.Services;
 
@@ -8,23 +7,17 @@ namespace TinYard.Extensions.CallbackTimer.Tests
     [TestClass]
     public class CallbackTimerTests
     {
-        private IContext _context;
         private CallbackTimerService _callbackTimer;
 
         [TestInitialize]
         public void Setup()
         {
-            _context = new Context();
-            _context.Install(new CallbackTimerExtension());
-            _context.Initialize();
-
-            _callbackTimer = _context.Mapper.GetMappingValue<ICallbackTimer>() as CallbackTimerService;
+            _callbackTimer = new CallbackTimerService();
         }
 
         [TestCleanup]
         public void Teardown()
         {
-            _context = null;
             _callbackTimer = null;
         }
 

--- a/TinYard/Extensions/CallbackTimer/API/Events/AddCallbackTimerEvent.cs
+++ b/TinYard/Extensions/CallbackTimer/API/Events/AddCallbackTimerEvent.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TinYard.Extensions.EventSystem.Impl.Base;
+
+namespace TinYard.Extensions.CallbackTimer.API.Events
+{
+    public class AddCallbackTimerEvent : Event
+    {
+        public enum Type
+        {
+            Add
+        }
+
+        public int TicksDuration { get; private set; } = -1;
+        public double SecondsDuration { get; private set; } = -1d;
+
+        public Action OnFinishedCallback { get; private set; }
+
+        public AddCallbackTimerEvent(Type type, int tickDuration, Action onFinishedCallback) : base(type)
+        {
+            TicksDuration = tickDuration;
+            OnFinishedCallback = onFinishedCallback;
+        }
+
+        public AddCallbackTimerEvent(Type type, double secondsDuration, Action onFinishedCallback) : base(type)
+        {
+            SecondsDuration = secondsDuration;
+            OnFinishedCallback = onFinishedCallback;
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/API/Events/RemoveCallbackTimerEvent.cs
+++ b/TinYard/Extensions/CallbackTimer/API/Events/RemoveCallbackTimerEvent.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using TinYard.Extensions.EventSystem.Impl.Base;
+
+namespace TinYard.Extensions.CallbackTimer.API.Events
+{
+    public class RemoveCallbackTimerEvent : Event
+    {
+        public enum Type
+        {
+            Remove
+        }
+
+        public Action CallbackToRemove { get; private set; }
+
+        public RemoveCallbackTimerEvent(Type type, Action callbackToRemove) : base(type)
+        {
+            CallbackToRemove = callbackToRemove;
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
+++ b/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
@@ -5,5 +5,6 @@ namespace TinYard.Extensions.CallbackTimer.API.Services
     public interface ICallbackTimer
     {
         void AddTimer(int ticks, Action callback);
+        void AddTimer(double seconds, Action callback);
     }
 }

--- a/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
+++ b/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
@@ -6,5 +6,7 @@ namespace TinYard.Extensions.CallbackTimer.API.Services
     {
         void AddTimer(int ticks, Action callback);
         void AddTimer(double seconds, Action callback);
+
+        bool RemoveTimer(Action callback);
     }
 }

--- a/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
+++ b/TinYard/Extensions/CallbackTimer/API/Services/ICallbackTimer.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace TinYard.Extensions.CallbackTimer.API.Services
+{
+    public interface ICallbackTimer
+    {
+        void AddTimer(int ticks, Action callback);
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
+++ b/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using TinYard.API.Interfaces;
+﻿using TinYard.API.Interfaces;
+using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CallbackTimer.Impl.Services;
 
 namespace TinYard.Extensions.CallbackTimer
 {
@@ -7,7 +8,7 @@ namespace TinYard.Extensions.CallbackTimer
     {
         public void Install(IContext context)
         {
-            throw new NotImplementedException();
+            context.Mapper.Map<ICallbackTimer>().ToValue(new CallbackTimerService());
         }
     }
 }

--- a/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
+++ b/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using TinYard.API.Interfaces;
+
+namespace TinYard.Extensions.CallbackTimer
+{
+    public class CallbackTimerExtension : IExtension
+    {
+        public void Install(IContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
+++ b/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
@@ -16,6 +16,7 @@ namespace TinYard.Extensions.CallbackTimer
             ICommandMap commandMap = context.Mapper.GetMappingValue<ICommandMap>();
 
             commandMap.Map<AddCallbackTimerEvent>(AddCallbackTimerEvent.Type.Add).ToCommand<AddCallbackTimerCommand>();
+            commandMap.Map<RemoveCallbackTimerEvent>(RemoveCallbackTimerEvent.Type.Remove).ToCommand<RemoveCallbackTimerCommand>();
         }
     }
 }

--- a/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
+++ b/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
@@ -1,6 +1,9 @@
 ﻿using TinYard.API.Interfaces;
+using TinYard.Extensions.CallbackTimer.API.Events;
 using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CallbackTimer.Impl.Commands;
 using TinYard.Extensions.CallbackTimer.Impl.Services;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
 
 namespace TinYard.Extensions.CallbackTimer
 {
@@ -9,6 +12,10 @@ namespace TinYard.Extensions.CallbackTimer
         public void Install(IContext context)
         {
             context.Mapper.Map<ICallbackTimer>().ToValue(new CallbackTimerService());
+
+            ICommandMap commandMap = context.Mapper.GetMappingValue<ICommandMap>();
+
+            commandMap.Map<AddCallbackTimerEvent>(AddCallbackTimerEvent.Type.Add).ToCommand<AddCallbackTimerCommand>();
         }
     }
 }

--- a/TinYard/Extensions/CallbackTimer/Impl/Commands/AddCallbackTimerCommand.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Commands/AddCallbackTimerCommand.cs
@@ -9,10 +9,10 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Commands
     public class AddCallbackTimerCommand : ICommand
     {
         [Inject]
-        public ICallbackTimer callbackTimer;
+        public AddCallbackTimerEvent evt;
 
         [Inject]
-        public AddCallbackTimerEvent evt;
+        public ICallbackTimer callbackTimer;
 
         public void Execute()
         {

--- a/TinYard/Extensions/CallbackTimer/Impl/Commands/AddCallbackTimerCommand.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Commands/AddCallbackTimerCommand.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using TinYard.Extensions.CallbackTimer.API.Events;
+using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Extensions.CallbackTimer.Impl.Commands
+{
+    public class AddCallbackTimerCommand : ICommand
+    {
+        [Inject]
+        public ICallbackTimer callbackTimer;
+
+        [Inject]
+        public AddCallbackTimerEvent evt;
+
+        public void Execute()
+        {
+            Action callback = evt.OnFinishedCallback;
+
+            if(evt.SecondsDuration >= 0d)
+            {
+                callbackTimer.AddTimer(evt.SecondsDuration, callback);
+            }
+            else if(evt.TicksDuration >= 0)
+            {
+                callbackTimer.AddTimer(evt.TicksDuration, callback);
+            }
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/Impl/Commands/RemoveCallbackTimerCommand.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Commands/RemoveCallbackTimerCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using TinYard.Extensions.CallbackTimer.API.Events;
+﻿using TinYard.Extensions.CallbackTimer.API.Events;
 using TinYard.Extensions.CallbackTimer.API.Services;
 using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Framework.Impl.Attributes;
@@ -16,7 +15,7 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Commands
 
         public void Execute()
         {
-            
+            callbackTimer.RemoveTimer(evt.CallbackToRemove);
         }
     }
 }

--- a/TinYard/Extensions/CallbackTimer/Impl/Commands/RemoveCallbackTimerCommand.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Commands/RemoveCallbackTimerCommand.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using TinYard.Extensions.CallbackTimer.API.Events;
+using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CommandSystem.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Extensions.CallbackTimer.Impl.Commands
+{
+    public class RemoveCallbackTimerCommand : ICommand
+    {
+        [Inject]
+        public RemoveCallbackTimerEvent evt;
+
+        [Inject]
+        public ICallbackTimer callbackTimer;
+
+        public void Execute()
+        {
+            
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -1,13 +1,103 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using TinYard.API.Interfaces;
 using TinYard.Extensions.CallbackTimer.API.Services;
+using TinYard.Extensions.CallbackTimer.Impl.VO;
+using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Extensions.CallbackTimer.Impl.Services
 {
     public class CallbackTimerService : ICallbackTimer
     {
+        [Inject]
+        public IContext context;
+
+        private System.Threading.CancellationTokenSource _updateLoopCancelToken;
+
+        private List<Timer> _timers = new List<Timer>();
+
+        public CallbackTimerService()
+        {
+            //TODO : Add in when added to IContext
+            //context.OnDestroy += OnDestroy;
+
+            _timers = new List<Timer>();
+            _updateLoopCancelToken = new System.Threading.CancellationTokenSource();
+
+            Task.Run(Update, _updateLoopCancelToken.Token);
+        }
+
+        ~CallbackTimerService()
+        {
+            OnDestroy();
+        }
+
+        private void OnDestroy()
+        {
+            if(!_updateLoopCancelToken.IsCancellationRequested)
+            {
+                _updateLoopCancelToken.Cancel();
+            }
+        }
+
+        private void Update()
+        {
+            double deltaTime = 0d;
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            while(true)
+            {
+                UpdateTimers(deltaTime);
+
+                deltaTime = stopwatch.Elapsed.TotalSeconds;
+                stopwatch.Restart();
+            }
+        }
+
+        /// <summary>
+        /// This is public for testing purposes only. 
+        /// Do not call this method unless you know what you are doing!
+        /// </summary>
+        /// <param name="deltaTime">Time interval since last update</param>
+        public void UpdateTimers(double deltaTime)
+        {
+            lock (_timers)
+            {
+                foreach(Timer timer in _timers)
+                {
+                    timer.Update(deltaTime);
+                }
+
+                _timers.RemoveAll(timer => timer.CurrentLifetime >= timer.TimerDuration);
+            }
+        }
+
         public void AddTimer(int ticks, Action callback)
         {
-            throw new NotImplementedException();
+            double ticksInSeconds = GetDurationOfTicksInSeconds(ticks);
+            CreateTimer(ticksInSeconds, callback);
+        }
+
+        public void AddTimer(double seconds, Action callback)
+        {
+            CreateTimer(seconds, callback);
+        }
+
+        private void CreateTimer(double durationInSeconds, Action callback)
+        {
+            Timer timer = new Timer(durationInSeconds, callback);
+
+            lock (_timers)
+                _timers.Add(timer);
+        }
+
+        private double GetDurationOfTicksInSeconds(int ticks)
+        {
+            //Number of ticks into seconds
+            return Stopwatch.Frequency * ticks;
         }
     }
 }

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using TinYard.Extensions.CallbackTimer.API.Services;
+
+namespace TinYard.Extensions.CallbackTimer.Impl.Services
+{
+    public class CallbackTimerService : ICallbackTimer
+    {
+        public void AddTimer(int ticks, Action callback)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -14,7 +14,7 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
         [Inject]
         public IContext context;
 
-        private System.Threading.CancellationTokenSource _updateLoopCancelToken;
+        private Task _updateTask;
 
         private List<Timer> _timers = new List<Timer>();
 
@@ -24,22 +24,8 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
             //context?.OnDestroy += OnDestroy;
 
             _timers = new List<Timer>();
-            _updateLoopCancelToken = new System.Threading.CancellationTokenSource();
 
-            Task.Run(Update, _updateLoopCancelToken.Token);
-        }
-
-        ~CallbackTimerService()
-        {
-            OnDestroy();
-        }
-
-        private void OnDestroy()
-        {
-            if(!_updateLoopCancelToken.IsCancellationRequested)
-            {
-                _updateLoopCancelToken.Cancel();
-            }
+            _updateTask = Task.Run(Update);
         }
 
         private void Update()

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -11,18 +11,12 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
 {
     public class CallbackTimerService : ICallbackTimer
     {
-        [Inject]
-        public IContext context;
-
         private Task _updateTask;
 
         private List<Timer> _timers = new List<Timer>();
 
         public CallbackTimerService()
         {
-            //TODO : Add in when added to IContext
-            //context?.OnDestroy += OnDestroy;
-
             _timers = new List<Timer>();
 
             _updateTask = Task.Run(Update);

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -86,6 +86,17 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
             CreateTimer(seconds, callback);
         }
 
+        public bool RemoveTimer(Action callbackToRemove)
+        {
+            int timersRemoved = 0;
+            lock(_timers)
+            {
+                timersRemoved = _timers.RemoveAll(timer => timer.TimerCallback == callbackToRemove);
+            }
+
+            return timersRemoved > 0;
+        }
+
         private void CreateTimer(double durationInSeconds, Action callback)
         {
             Timer timer = new Timer(durationInSeconds, callback);

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -21,7 +21,7 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
         public CallbackTimerService()
         {
             //TODO : Add in when added to IContext
-            //context.OnDestroy += OnDestroy;
+            //context?.OnDestroy += OnDestroy;
 
             _timers = new List<Timer>();
             _updateLoopCancelToken = new System.Threading.CancellationTokenSource();

--- a/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/Services/CallbackTimerService.cs
@@ -53,6 +53,8 @@ namespace TinYard.Extensions.CallbackTimer.Impl.Services
                 UpdateTimers(deltaTime);
 
                 deltaTime = stopwatch.Elapsed.TotalSeconds;
+
+                //TODO : Look at if we can improve performance here by not using restart and instead tracking previous elapsed time
                 stopwatch.Restart();
             }
         }

--- a/TinYard/Extensions/CallbackTimer/Impl/VO/Timer.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/VO/Timer.cs
@@ -4,34 +4,31 @@ namespace TinYard.Extensions.CallbackTimer.Impl.VO
 {
     public class Timer
     {
-        public Action TimerCallback { get { return _timerCallback; } }
-        private Action _timerCallback;
+        public Action TimerCallback { get; private set; }
 
-        public double TimerDuration { get { return _timerDuration; } }
-        private double _timerDuration;
+        public double TimerDuration { get; private set; }
 
-        public double CurrentLifetime { get { return _currentLifetime; } }
-        private double _currentLifetime;
+        public double CurrentLifetime { get; private set; }
 
         private bool _timerFinished = false;
 
         public Timer(double durationInSeconds, Action timerCallback)
         {
-            _timerDuration = durationInSeconds;
-            _currentLifetime = 0d;
+            TimerDuration = durationInSeconds;
+            CurrentLifetime = 0d;
 
-            _timerCallback = timerCallback;
+            TimerCallback = timerCallback;
         }
 
         public void Update(double deltaTime)
         {
-            _currentLifetime += deltaTime;
+            CurrentLifetime += deltaTime;
 
-            if (!_timerFinished && _currentLifetime >= TimerDuration)
+            if (!_timerFinished && CurrentLifetime >= TimerDuration)
             {
                 _timerFinished = true;
 
-                _timerCallback?.Invoke();
+                TimerCallback?.Invoke();
             }
         }
     }

--- a/TinYard/Extensions/CallbackTimer/Impl/VO/Timer.cs
+++ b/TinYard/Extensions/CallbackTimer/Impl/VO/Timer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace TinYard.Extensions.CallbackTimer.Impl.VO
+{
+    public class Timer
+    {
+        public Action TimerCallback { get { return _timerCallback; } }
+        private Action _timerCallback;
+
+        public double TimerDuration { get { return _timerDuration; } }
+        private double _timerDuration;
+
+        public double CurrentLifetime { get { return _currentLifetime; } }
+        private double _currentLifetime;
+
+        private bool _timerFinished = false;
+
+        public Timer(double durationInSeconds, Action timerCallback)
+        {
+            _timerDuration = durationInSeconds;
+            _currentLifetime = 0d;
+
+            _timerCallback = timerCallback;
+        }
+
+        public void Update(double deltaTime)
+        {
+            _currentLifetime += deltaTime;
+
+            if (!_timerFinished && _currentLifetime >= TimerDuration)
+            {
+                _timerFinished = true;
+
+                _timerCallback?.Invoke();
+            }
+        }
+    }
+}

--- a/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
+++ b/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
@@ -13,18 +13,14 @@ namespace TinYard.Extensions.CommandSystem
         public void Install(IContext context)
         {
             _context = context;
-            _context.PostConfigsInstalled += PostConfigsInstalled;
+
+            SetupCommandMap();
         }
 
-        private void PostConfigsInstalled()
+        private void SetupCommandMap()
         {
             var eventDispatcher = _context.Mapper.GetMappingValue<IEventDispatcher>();
             var injector = _context.Injector;
-
-            if(eventDispatcher == null || injector == null)
-            {
-                throw new NullReferenceException("Event Dispatcher or Injector are null in CommandSystemExtension");
-            }
 
             EventCommandMap commandMap = new EventCommandMap(eventDispatcher, injector);
             _context.Mapper.Map<ICommandMap>().ToValue(commandMap);


### PR DESCRIPTION
A new extension; the `CallbackTimerExtension`.

The Callback Timer Extension provides you the ability to easily invoke any Action in any amount of time from now. 
Need to dispatch an event in 5 seconds? Use the Callback Timer instead of writing some messy get around. 

To use the `ICallbackTimer` you can `inject` it into your anything, or use the new `event`s provided.

* What is new?
  * Added the `CallbackTimerExtension`
  * Added the `ICallbackTimer` interface
  * Added the `CallbackTimerService` service, that is mapped to the `Context` under the `ICallbackTimer` interface.
  * Added the `AddCallbackTimerEvent` and `RemoveCallbackTimerEvent` that can be used to add and remove callback timers respectively using `event`s instead of having to `inject` the `ICallbackTimer`.
  * Added the `AddCallbackTimerCommand` and `RemoveCallbackTimerCommand` that handle said `event`s.
  * Added the `Timer` VO that is used in the `CallbackTimerService`.
* What has changed?
  * The `CommandSystemExtension` is now less shit. It `map`s the `ICommandMap` in the `Install` phase rather than the `Post Initialize` phase of the `Context` `Initialize` cycle. This means that any `extension` reliant on the `ICommandMap` just has to ensure it is installed after the `CommandSystemExtension` and not wait until the `Post Initialize` hook has called.

**Dependencies**
* `EventSystemExtension`
* `CommandSystemExtension`

Related issues?    
Resolves #59 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes