### PR TITLE
Multiple WithGuard Overrides

### DIFF
--- a/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/API/Interfaces/ICommandMapping.cs
@@ -20,5 +20,9 @@ namespace TinYard.Extensions.CommandSystem.API.Interfaces
         ICommandMapping ToCommand<T>() where T : ICommand;
 
         ICommandMapping WithGuard<T>() where T : Guard;
+        ICommandMapping WithGuard<T1, T2>() where T1 : Guard where T2 : Guard;
+        ICommandMapping WithGuard<T1, T2, T3>() where T1 : Guard where T2 : Guard where T3 : Guard;
+        ICommandMapping WithGuard<T1, T2, T3, T4>() where T1 : Guard where T2 : Guard where T3 : Guard where T4 : Guard;
+        ICommandMapping WithGuard<T1, T2, T3, T4, T5>() where T1 : Guard where T2 : Guard where T3 : Guard where T4 : Guard where T5 : Guard;
     }
 }

--- a/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
+++ b/TinYard/Extensions/CommandSystem/Impl/VO/CommandMapping.cs
@@ -40,5 +40,43 @@ namespace TinYard.Extensions.CommandSystem.Impl.VO
 
             return this;
         }
+
+        public ICommandMapping WithGuard<T1, T2>() where T1 : Guard where T2 : Guard
+        {
+            _guardTypes.Add(typeof(T1));
+            _guardTypes.Add(typeof(T2));
+
+            return this;
+        }
+
+        public ICommandMapping WithGuard<T1, T2, T3>() where T1 : Guard where T2 : Guard where T3 : Guard
+        {
+            _guardTypes.Add(typeof(T1));
+            _guardTypes.Add(typeof(T2));
+            _guardTypes.Add(typeof(T3));
+
+            return this;
+        }
+
+        public ICommandMapping WithGuard<T1, T2, T3, T4>() where T1 : Guard where T2 : Guard where T3 : Guard where T4 : Guard
+        {
+            _guardTypes.Add(typeof(T1));
+            _guardTypes.Add(typeof(T2));
+            _guardTypes.Add(typeof(T3));
+            _guardTypes.Add(typeof(T4));
+
+            return this;
+        }
+
+        public ICommandMapping WithGuard<T1, T2, T3, T4, T5>() where T1 : Guard where T2 : Guard where T3 : Guard where T4 : Guard where T5 : Guard
+        {
+            _guardTypes.Add(typeof(T1));
+            _guardTypes.Add(typeof(T2));
+            _guardTypes.Add(typeof(T3));
+            _guardTypes.Add(typeof(T4));
+            _guardTypes.Add(typeof(T5));
+
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Added WithGuard overrides to improve adding guards to Commands.

* What has changed?
  * `ICommandMapping` and `CommandMapping` have now got more `WithGuard` overrides for multiple `Guard`s.

Related issues?
Resolves #62 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes