### PR TITLE
Feature/constructor injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ The [`MappingValueFactory`](#MappingValueFactory) is used by the [`ValueMapper`]
 
 As all [`IMappingObject`](#IMappingObject)'s have a method that might need a value object to be created, the [`ValueMapper`](#ValueMapper) provides the [`MappingObject`](#MappingObject) with its factory to create that value from.
 
+Internally, the `BuildValue<T>` method uses the [`IInjector`](#IInjector) that is mapped to its parent [`IMapper`](#IMapper) after determining the type required.  
+
 #### GuardFactory
 
 The [`GuardFactory`](#GuardFactory) is created and mapped in the [`Context`](#Context) to `IGuardFactory`. The [`GuardFactory`](#GuardFactory) is a super simple [`Factory`](#IFactory) that creates [`IGuard`](#IGuard)'s via the `Activator` class - Expecting the [`IGuard`](#IGuard) to have a parameterless constructor and be derived from the [`Guard`](#Guard) base class.

--- a/README.md
+++ b/README.md
@@ -239,13 +239,17 @@ The `BuildValue<T>()` function can create the `MappedValue` object of type `T` f
 
 ### IInjector
 
-An `IInjector` should provide three easy-to-use `Inject` methods.
+An `IInjector` should provide two easy-to-use `Inject` methods, and twi `CreateInjected` methods.
 
-One `Inject` method should provide an object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
+The first `Inject` method should provide an object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
 
 The second `Inject` method should have `target` and `value` objects passed as arguments. The `target` object should be injected into, specifically looking to provide it with the `value` object if possible.
  
-The third `Inject` method should be provided with a Generic `T` parameter. This `Inject` method works slightly different than the others - It will create and return an instance of Type `T` that is has created via Constructor Injection.
+The `CreateInjected` method has two versions:
+
+One should be provided with a Generic `T` parameter. This method will create and return an instance of Type `T` that is has created via Constructor Injection and provided dependencies.
+
+The other is identical except that it accepts a `Type` parameter instead of a Generic.
 
 All [`IInjector`](#IInjector)'s should also have an internal collection of values that can be injected into any class when the first `Inject` method is called upon it. This collection should be added to / provided to the [`IInjector`](#IInjector) via the `AddInjectable` method. 
 
@@ -253,9 +257,11 @@ All [`IInjector`](#IInjector)'s should also have an internal collection of value
 
 `TinYardInjector` is the standard implementation of [`IInjector`](#IInjector) used by the [standard `IContext` implementation](#Context).
 
-`TinYardInjector` requires an [`IContext`](#IContext) object to be passed to it when constructed.
+`TinYardInjector` requires an [`IContext`](#IContext) and an [`IMapper`](#IMapper) to be passed to it when constructed.
 
 `TinYardInjector` provides the 'injected' value of a Field by finding a [`Mapping`](#IMappingObject) of the Field via the [`IContext`](#IContext) provided in construction and the [`IMapper`](#IMapper) that it has, alongside its internal collection that can be added to via the `AddInjectable` method.
+
+To perform Construction Injection, you need to use one of the `CreateInjected` methods. Internally these methods are identical, the Generic version calls the non-Generic version with `typeof(T)`. The `TinYardInjector` will firstly identify any constructors for the object Type that are marked with the [`Inject` attribute](#Inject-Attribute), if any are found it will attempt to create the object with these constructors as a priority - it then will attempt to create the object by finding the constructor it can provide the most parameters to.
 
 #### Inject Attribute
 

--- a/README.md
+++ b/README.md
@@ -239,12 +239,14 @@ The `BuildValue<T>()` function can create the `MappedValue` object of type `T` f
 
 ### IInjector
 
-An `IInjector` should provide two easy-to-use `Inject` methods.
+An `IInjector` should provide three easy-to-use `Inject` methods.
 
 One `Inject` method should provide an object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
 
-The other `Inject` method should have `target` and `value` objects passed as arguments. The `target` object should be injected into, specifically looking to provide it with the `value` object if possible.
+The second `Inject` method should have `target` and `value` objects passed as arguments. The `target` object should be injected into, specifically looking to provide it with the `value` object if possible.
  
+The third `Inject` method should be provided with a Generic `T` parameter. This `Inject` method works slightly different than the others - It will create and return an instance of Type `T` that is has created via Constructor Injection.
+
 All [`IInjector`](#IInjector)'s should also have an internal collection of values that can be injected into any class when the first `Inject` method is called upon it. This collection should be added to / provided to the [`IInjector`](#IInjector) via the `AddInjectable` method. 
 
 #### TinYardInjector
@@ -257,9 +259,9 @@ All [`IInjector`](#IInjector)'s should also have an internal collection of value
 
 #### Inject Attribute
 
-The `Inject` attribute can be added to any Field.
+The `Inject` attribute can be added to any Field or Class Constructor.
 
-The `Inject` attribute acts as a flag to the [`IMapper`](#IMapper) in your [`IContext`](#IContext).
+The `Inject` attribute acts as a flag to the [`IInjector`](#IInjector) in your [`IContext`](#IContext).
 
 In the standard implementation of [`IContext`](#IContext), [`Context`](#Context) -
 When a value is added to an [`IMappingObject`](#IMappingObject), the [`IMapper`](#IMapper) lets the [`IContext`](#IContext) know that the value needs injecting into, which in turn tells its [`IInjector`](#IInjector) to Inject into it.

--- a/TinYard.Tests/TestClasses/MockInjector.cs
+++ b/TinYard.Tests/TestClasses/MockInjector.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using TinYard.Framework.API.Interfaces;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class MockInjector : IInjector
+    {
+        public void AddInjectable(Type injectableType, object injectableObject)
+        {
+        }
+
+        public T CreateInjected<T>()
+        {
+            return (T)CreateInjected(typeof(T));
+        }
+
+        public object CreateInjected(Type targetType)
+        {
+            return Activator.CreateInstance(targetType);
+        }
+
+        public void Inject(object target)
+        {
+            
+        }
+
+        public void Inject(object target, object value)
+        {
+            
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestCreatable.cs
+++ b/TinYard.Tests/TestClasses/TestCreatable.cs
@@ -6,6 +6,11 @@ namespace TinYard.Tests.TestClasses
     {
         public IContext Context { get; }
 
+        public TestCreatable()
+        {
+
+        }
+
         public TestCreatable(IContext context)
         {
             Context = context;

--- a/TinYard.Tests/TestClasses/TestInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestInjectable.cs
@@ -6,5 +6,17 @@ namespace TinYard_Tests.TestClasses
     {
         [Inject]
         public int Value;
+
+        public float ConstructedFloat { get; private set; }
+
+        public TestInjectable()
+        {
+
+        }
+
+        public TestInjectable(float injectableFloat)
+        {
+            ConstructedFloat = injectableFloat;
+        }
     }
 }

--- a/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
@@ -6,5 +6,26 @@ namespace TinYard_Tests.TestClasses
     {
         [Inject]
         public TestInjectable InjectedValue;
+
+        public float InjectableFloat { get; private set; }
+        public double InjectableDouble { get; private set; }
+
+        public TestSecondaryInjectable()
+        {
+
+        }
+
+        public TestSecondaryInjectable(float injectableFloat, double injectableDouble)
+        {
+            InjectableFloat = injectableFloat;
+
+            //Don't set the double, we want a constructor which has more parameters so we can make sure its choosing the attributed one
+        }
+
+        [Inject]
+        public TestSecondaryInjectable(double injectableDouble)
+        {
+            InjectableDouble = injectableDouble;
+        }
     }
 }

--- a/TinYard.Tests/Tests/InjectionAttributeTests.cs
+++ b/TinYard.Tests/Tests/InjectionAttributeTests.cs
@@ -20,9 +20,17 @@ namespace TinYard.Tests
         [TestMethod]
         public void Inject_Attribute_Provides_Fields_To_Inject_Into()
         {
-            object[] fields = InjectAttribute.GetInjectables(typeof(TestInjectable)).ToArray();
+            var fields = InjectAttribute.GetInjectableFields(typeof(TestInjectable));
 
-            Assert.IsTrue(fields.Length > 0);
+            Assert.IsTrue(fields.Count > 0);
+        }
+
+        [TestMethod]
+        public void Inject_Attribute_Provides_Constructors_To_Inject_Into()
+        {
+            var constructors = InjectAttribute.GetInjectableConstructors(typeof(TestSecondaryInjectable));
+
+            Assert.IsTrue(constructors.Count > 0);
         }
     }
 }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -111,5 +111,20 @@ namespace TinYard.Tests
 
             Assert.AreEqual(constructed.ConstructedFloat, expected);
         }
+
+        [TestMethod]
+        public void Injector_Prefers_Attributed_Constructor()
+        {
+            float expectedFloat = 3.14f;
+            double expectedDouble = 3.147d;
+
+            _context.Mapper.Map<float>().ToValue(expectedFloat);
+            _context.Mapper.Map<double>().ToValue(expectedDouble);
+
+            TestSecondaryInjectable constructed = _injector.Inject<TestSecondaryInjectable>();
+
+            Assert.AreNotEqual(constructed.InjectableFloat, expectedFloat);
+            Assert.AreEqual(constructed.InjectableDouble, expectedDouble);
+        }
     }
 }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -100,5 +100,16 @@ namespace TinYard.Tests
 
             Assert.AreEqual(expected, injectable.Value);
         }
+
+        [TestMethod]
+        public void Injector_Can_Create_Injectable_Constructor()
+        {
+            float expected = 3.14f;
+            _context.Mapper.Map<float>().ToValue(expected);
+
+            TestInjectable constructed = _injector.Inject<TestInjectable>();
+
+            Assert.AreEqual(constructed.ConstructedFloat, expected);
+        }
     }
 }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -16,7 +16,7 @@ namespace TinYard.Tests
         public void Setup()
         {
             _context = new Context();
-            _injector = new TinYardInjector(_context);
+            _injector = new TinYardInjector(_context, _context.Mapper);
         }
 
         [TestCleanup]
@@ -107,7 +107,7 @@ namespace TinYard.Tests
             float expected = 3.14f;
             _context.Mapper.Map<float>().ToValue(expected);
 
-            TestInjectable constructed = _injector.Inject<TestInjectable>();
+            TestInjectable constructed = _injector.CreateInjected<TestInjectable>();
 
             Assert.AreEqual(constructed.ConstructedFloat, expected);
         }
@@ -121,7 +121,7 @@ namespace TinYard.Tests
             _context.Mapper.Map<float>().ToValue(expectedFloat);
             _context.Mapper.Map<double>().ToValue(expectedDouble);
 
-            TestSecondaryInjectable constructed = _injector.Inject<TestSecondaryInjectable>();
+            TestSecondaryInjectable constructed = _injector.CreateInjected<TestSecondaryInjectable>();
 
             Assert.AreNotEqual(constructed.InjectableFloat, expectedFloat);
             Assert.AreEqual(constructed.InjectableDouble, expectedDouble);

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using TinYard.API.Interfaces;
+using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Mappers;
 using TinYard.Tests.TestClasses;
 
@@ -15,6 +16,8 @@ namespace TinYard.Tests
         public void Setup()
         {
             _mapper = new ValueMapper();
+            //Need a MockInjector for the internal Factory
+            _mapper.Map<IInjector>().ToValue(new MockInjector());
         }
 
         [TestCleanup]

--- a/TinYard/Framework/API/Interfaces/IInjector.cs
+++ b/TinYard/Framework/API/Interfaces/IInjector.cs
@@ -6,7 +6,9 @@ namespace TinYard.Framework.API.Interfaces
     {
         void AddInjectable(Type injectableType, object injectableObject);
 
-        T Inject<T>();
+        T CreateInjected<T>();
+        object CreateInjected(Type targetType);
+
         void Inject(object target);
         void Inject(object target, object value);
     }

--- a/TinYard/Framework/API/Interfaces/IInjector.cs
+++ b/TinYard/Framework/API/Interfaces/IInjector.cs
@@ -6,7 +6,8 @@ namespace TinYard.Framework.API.Interfaces
     {
         void AddInjectable(Type injectableType, object injectableObject);
 
-        void Inject(object classToInjectInto);
+        T Inject<T>();
+        void Inject(object target);
         void Inject(object target, object value);
     }
 }

--- a/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
+++ b/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
@@ -6,10 +6,10 @@ using System.Reflection;
 namespace TinYard.Framework.Impl.Attributes
 {
     //TODO: See if we can allow injection into Properties.. Might be an issue due to private sets?
-    [AttributeUsage(AttributeTargets.Field /*| AttributeTargets.Property*/, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Constructor /*| AttributeTargets.Property*/, AllowMultiple = false, Inherited = true)]
     public class InjectAttribute : Attribute
     {
-        public static List<FieldInfo> GetInjectables(Type classToInjectInto)
+        public static List<FieldInfo> GetInjectableFields(Type classToInjectInto)
         {
             List<FieldInfo> injectables = new List<FieldInfo>();
             
@@ -20,6 +20,19 @@ namespace TinYard.Framework.Impl.Attributes
             }
 
             return injectables;
+        }
+
+        public static List<ConstructorInfo> GetInjectableConstructors(Type classToInjectInto)
+        {
+            List<ConstructorInfo> injectableConstructors = new List<ConstructorInfo>();
+
+            foreach(ConstructorInfo constructor in classToInjectInto.GetConstructors())
+            {
+                if (constructor.GetCustomAttributes<InjectAttribute>(true).Count() > 0)
+                    injectableConstructors.Add(constructor);
+            }
+
+            return injectableConstructors;
         }
     }
 }

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -57,7 +57,7 @@ namespace TinYard
             _mapper = new ValueMapper();
             _mapper.OnValueMapped += InjectValueMapper;
 
-            _injector = new TinYardInjector(this);
+            _injector = new TinYardInjector(this, _mapper);
 
             //Ensure the context, mapper and injector are mapped for injection needs
             _mapper.Map<IContext>().ToValue(this);

--- a/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
+++ b/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
@@ -43,34 +43,8 @@ namespace TinYard.Framework.Impl.Factories
             if (type == null)
                 type = mappingObject.MappedType;
 
-            object[] constructorDependencies = GetConstructorDependencies(type);
-
-            //If we have any null objects, we can break something further down the line.
-            //Making the array null means we should use the default constructor instead when possible
-            if (constructorDependencies.Any().GetType() == null)
-                constructorDependencies = null;
-
-            object value = Activator.CreateInstance(type, constructorDependencies);
+            object value = _mapper.GetMappingValue<IInjector>().CreateInjected(type);
             return mappingObject.ToValue(value);
-        }
-
-        private object[] GetConstructorDependencies(Type type)
-        {
-            ParameterInfo[] constructorInfo = type.GetConstructors().FirstOrDefault().GetParameters();
-
-            List<object> constructorParams = new List<object>();
-            foreach(ParameterInfo constructorParameter in constructorInfo)
-            {
-                object value = GetValueFromMapper(constructorParameter.ParameterType);
-                constructorParams.Add(value);
-            }
-
-            return constructorParams.ToArray();
-        }
-
-        private object GetValueFromMapper(Type parameterType)
-        {
-            return _mapper.GetMappingValue(parameterType);
         }
     }
 }

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
@@ -136,10 +137,9 @@ namespace TinYard.Framework.Impl.Injectors
             //If no attributed constructors could be completed, lets try normal ones
             if (targetConstructor == null)
             {
-                constructorsToCompare.Clear();
-                constructorsToCompare.AddRange(targetType.GetConstructors());
-
-                targetConstructor = GetMostInjectableConstructor(constructorsToCompare);
+                //Get constructors that haven't got the attribute via filtering
+                IEnumerable<ConstructorInfo> remainingConstructors = targetType.GetConstructors().Except(constructorsToCompare);
+                targetConstructor = GetMostInjectableConstructor(remainingConstructors);
             }
 
             return targetConstructor;

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -27,35 +27,18 @@ namespace TinYard.Framework.Impl.Injectors
             _extraInjectables[injectableType] = injectableObject;
         }
 
-        public void Inject(object classToInjectInto)
+        public void Inject(object target)
         {
             //GetType as it's correct at run-time rather than compile time!
-            Type classType = classToInjectInto.GetType();
+            Type targetType = target.GetType();
 
-            List<FieldInfo> injectables = InjectAttribute.GetInjectables(classType);
-
-            foreach(FieldInfo field in injectables)
-            {
-                Type fieldType = field.FieldType;
-                if(_mapper.GetMapping(fieldType) != null)
-                {
-                    var valueToInject = _mapper.GetMappingValue(fieldType);
-                    Inject(valueToInject);
-
-                    field.SetValue(classToInjectInto, _mapper.GetMappingValue(fieldType));
-                }
-                else if(_extraInjectables.ContainsKey(fieldType))
-                {
-                    var valueToInject = _extraInjectables[fieldType];
-                    Inject(valueToInject);
-                    field.SetValue(classToInjectInto, valueToInject);
-                }
-            }
+            InjectValues(target, targetType);
         }
 
         public void Inject(object target, object value)
         {
-            List<FieldInfo> injectables = InjectAttribute.GetInjectables(target.GetType());
+            Type targetType = target.GetType();
+            List<FieldInfo> injectables = InjectAttribute.GetInjectables(targetType);
 
             Type valueType = value.GetType();
 
@@ -66,6 +49,29 @@ namespace TinYard.Framework.Impl.Injectors
                 if(valueType == fieldType || fieldType.IsAssignableFrom(valueType))
                 {
                     field.SetValue(target, value);
+                }
+            }
+        }
+
+        private void InjectValues(object target, Type targetType)
+        {
+            List<FieldInfo> injectables = InjectAttribute.GetInjectables(targetType);
+
+            foreach (FieldInfo field in injectables)
+            {
+                Type fieldType = field.FieldType;
+                if (_mapper.GetMapping(fieldType) != null)
+                {
+                    var valueToInject = _mapper.GetMappingValue(fieldType);
+                    Inject(valueToInject);
+
+                    field.SetValue(target, _mapper.GetMappingValue(fieldType));
+                }
+                else if (_extraInjectables.ContainsKey(fieldType))
+                {
+                    var valueToInject = _extraInjectables[fieldType];
+                    Inject(valueToInject);
+                    field.SetValue(target, valueToInject);
                 }
             }
         }

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -74,6 +74,7 @@ namespace TinYard.Framework.Impl.Injectors
                 for(int i = 0; i < constructorParams.Length; i++)
                 {
                     object value = GetInjectableValue(constructorParams[i].ParameterType);
+                    Inject(value);
 
                     parameters[i] = value;
                 }


### PR DESCRIPTION
Constructor injection! 

The `IInjector` interface now has an `Inject` overload that takes a Generic. It is expected that the implementation of this returns a newly constructed class of Type T which has been created with the most applicable Constructor in which it provides values to.

The `TinYard Injector` implements this change and does as above - choosing the highest parameter constructor it can successfully invoke.
The `TinYard Injector` takes a preference of Constructors marked with the `[Inject]` attribute, as this is considered explicit.


* What is new?
  * Added `CreateInjected<T>` method to `IInjector`.
  * Added `CreateInjected<T>` method that provides Constructor injection to `TinYardInjector`.
  * Added `CreateInjected(Type targetType)` method to `IInjector` and impl in `TinYardInjector`.
  * `[Inject]` attribute can now be added to Constructors.
  * `InjectAttribute` class has new static method: `GetInjectableConstructors(Type classToInjectInto)`.
* What has changed?
  * Some refactor and tidy to `TinYardInjector`
  * `TinYardInjector` now has an `IMapper` dependency in its Constructor.
  * `MappingValueFactory` now internally uses the mapped `IInjector` in the `BuildValue<T>` method to use Constructor Injection.

Related issues?    
Resolves #75  & #69 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes