### PR TITLE
Feature / Mapping Build Delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Internally, `Map<T>()` on the `ValueMapper` calls `Map<T>()` on a newly created 
 
 The `BuildValue<T>()` function can create the `MappedValue` object of type `T` for you. This should have a default implementation, but you can also modify how this works by setting the `BuildDelegate<IMappingObject, Type>` Action.
 
+The `BuildDelegate<IMappingObject, Type>` Action, when invoked, should provide you the `IMappingObject` that is calling it and the type of the generic `T` passed into the `BuildValue<T>` function.
+
 #### MappingObject
 
 `MappingObject` provides a super-simple implementation of [`IMappingObject`](#IMappingObject) that is used by [`ValueMapper`](#ValueMapper). 

--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ Internally, `Map<T>()` on the `ValueMapper` calls `Map<T>()` on a newly created 
 
 `MappedValue` is then the value that is set with the `ToValue(object value)` method.
 
-The `BuildValue<T>()` function can create the `MappedValue` object of type `T` for you. It should be doing this via a Factory it has access to.
+The `BuildValue<T>()` function can create the `MappedValue` object of type `T` for you. This should have a default implementation, but you can also modify how this works by setting the `BuildDelegate<IMappingObject, Type>` Action.
 
 #### MappingObject
 
 `MappingObject` provides a super-simple implementation of [`IMappingObject`](#IMappingObject) that is used by [`ValueMapper`](#ValueMapper). 
 
-`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when `BuildValue<T>` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value.
+`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when the default `BuildValue<T>` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value unless an override has been provided on the `BuildDelegate<IMappingObject, Type>` Action.
 
 ### IInjector
 

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -60,7 +60,7 @@ namespace TinYard.Tests
         {
             int expected = 4096;
 
-            Action<IMappingObject> overrideBuild = new Action<IMappingObject>((mappingObj) =>
+            Action<IMappingObject, Type> overrideBuild = new Action<IMappingObject, Type>((mappingObj, valType) =>
             {
                 mappingObj.ToValue(expected);
             });

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -3,6 +3,7 @@ using System;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Mappers;
+using TinYard.Impl.VO;
 using TinYard.Tests.TestClasses;
 
 namespace TinYard.Tests
@@ -52,6 +53,24 @@ namespace TinYard.Tests
 
             Assert.IsNotNull(actual);
             Assert.IsInstanceOfType(actual, expected);
+        }
+
+        [TestMethod]
+        public void MappingObject_Build_Functionality_Can_Be_Overwritten()
+        {
+            int expected = 4096;
+
+            Action<IMappingObject> overrideBuild = new Action<IMappingObject>((mappingObj) =>
+            {
+                mappingObj.ToValue(expected);
+            });
+
+            MappingObject mappingObject = new MappingObject();
+            mappingObject.BuildDelegate = overrideBuild;
+            mappingObject.Map<int>();
+            mappingObject.BuildValue<int>();
+
+            Assert.AreEqual(expected, mappingObject.MappedValue);
         }
     }
 }

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -9,6 +9,8 @@ namespace TinYard.Impl.VO
 
         event Action<IMappingObject> OnValueMapped;
 
+        Action<IMappingObject> BuildDelegate { get; set; }
+
         IMappingObject Map<T>();
         IMappingObject Map(Type type);
 

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -9,7 +9,7 @@ namespace TinYard.Impl.VO
 
         event Action<IMappingObject> OnValueMapped;
 
-        Action<IMappingObject> BuildDelegate { get; set; }
+        Action<IMappingObject, Type> BuildDelegate { get; set; }
 
         IMappingObject Map<T>();
         IMappingObject Map(Type type);

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -13,14 +13,17 @@ namespace TinYard.Impl.VO
 
         public event Action<IMappingObject> OnValueMapped;
 
+        public Action<IMappingObject> BuildDelegate { get; set; }
+        private readonly Action<IMappingObject> _defaultBuildDelegate;
+
         private IMapper _parentMapper;
 
         public MappingObject()
         {
-
+            _defaultBuildDelegate = (obj) => obj.ToValue(_parentMapper?.MappingFactory?.Build(obj).MappedValue);
         }
 
-        public MappingObject(IMapper parentMapper)
+        public MappingObject(IMapper parentMapper) : this()
         {
             _parentMapper = parentMapper;
         }
@@ -50,8 +53,15 @@ namespace TinYard.Impl.VO
         public IMappingObject BuildValue<T>()
         {
             _mappedValue = typeof(T);
-            
-            _mappedValue = _parentMapper?.MappingFactory?.Build(this).MappedValue;
+
+            if (BuildDelegate != null)
+            {
+                BuildDelegate.Invoke(this);
+            }
+            else
+            {
+                _defaultBuildDelegate.Invoke(this);
+            }
 
             if (OnValueMapped != null)
                 OnValueMapped.Invoke(this);

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -13,14 +13,14 @@ namespace TinYard.Impl.VO
 
         public event Action<IMappingObject> OnValueMapped;
 
-        public Action<IMappingObject> BuildDelegate { get; set; }
-        private readonly Action<IMappingObject> _defaultBuildDelegate;
+        public Action<IMappingObject, Type> BuildDelegate { get; set; }
+        private readonly Action<IMappingObject, Type> _defaultBuildDelegate;
 
         private IMapper _parentMapper;
 
         public MappingObject()
         {
-            _defaultBuildDelegate = (obj) => obj.ToValue(_parentMapper?.MappingFactory?.Build(obj).MappedValue);
+            _defaultBuildDelegate = (obj, _) => obj.ToValue(_parentMapper?.MappingFactory?.Build(obj).MappedValue);
         }
 
         public MappingObject(IMapper parentMapper) : this()
@@ -52,15 +52,16 @@ namespace TinYard.Impl.VO
 
         public IMappingObject BuildValue<T>()
         {
-            _mappedValue = typeof(T);
+            Type valueType = typeof(T);
 
             if (BuildDelegate != null)
             {
-                BuildDelegate.Invoke(this);
+                BuildDelegate.Invoke(this, valueType);
             }
             else
             {
-                _defaultBuildDelegate.Invoke(this);
+                _mappedValue = typeof(T);
+                _defaultBuildDelegate.Invoke(this, valueType);
             }
 
             if (OnValueMapped != null)


### PR DESCRIPTION
Sometimes you may need a specific way to build an IMappingObjects value, especially when dealing with legacy code or external classes where the de-facto Build functionality doesn't do everything required.

This Feature allows you to override the default `BuildValue<T>` method used in an `IMappingObject`, by setting the `BuildDelegate<IMappingObject, Type>` Action.

* What is new?
  * Added the `BuildDelegate` Action to `IMappingObject` and `MappingObject` classes.
* What has changed?
  * `MappingObject` impl of `BuildValue` now calls the `BuildDelegate` Action if it has been set, or the `_defaultBuildDelegate` Action if not. This 'default' is set in the constructor to do the same functionality as before.

Related issues?    
Resolves #79 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes