### PR TITLE
Feature/named injection values

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Currently, all that happens here is that the Post Initalize Hook is invoked.
 
 `IMapper` should be implemented by an object that is going to be providing Mapping functionality.
 
-Mapping is where we can 'map' an object, to another - They're linked.
+Mapping is where we can 'map' an object, to another - They're linked. When we `Map` something, we can also provide it with a `Name` to help with filtering later on. This should be an optional parameter in the `Map` functions.
 
 `IMapper` should also make use of [`IMappingObject`](#IMappingObject)'s to be consistent across implementations.
 
@@ -214,12 +214,18 @@ This example, means that when we request the Value of [`IContext`](#IContext) fr
 
 `IMappingObject` is used in tandem with [`IMapper`](#IMapper). 
 
-`IMappingObject` has two components:
+`IMappingObject` has three components, the two main ones are:
 
 * `MappedType`
 * `MappedValue`
 
 `MappedType` is the `type` that this `IMappingObject` is a reference to.
+
+The third component is:
+
+* `Name`
+
+The `Name` is simply an extra, and optional, property to help differentiate `IMappingObject`s.
 
 So, looking at the example used in [Value Mapper](#ValueMapper):
 
@@ -241,7 +247,7 @@ The `BuildDelegate<IMappingObject, Type>` Action, when invoked, should provide y
 
 ### IInjector
 
-An `IInjector` should provide two easy-to-use `Inject` methods, and twi `CreateInjected` methods.
+An `IInjector` should provide two easy-to-use `Inject` methods, and two `CreateInjected` methods.
 
 The first `Inject` method should provide an object, that has been provided as a parameter, values to any Field that has the [`Inject` attribute](#Inject-Attribute).
 
@@ -261,7 +267,7 @@ All [`IInjector`](#IInjector)'s should also have an internal collection of value
 
 `TinYardInjector` requires an [`IContext`](#IContext) and an [`IMapper`](#IMapper) to be passed to it when constructed.
 
-`TinYardInjector` provides the 'injected' value of a Field by finding a [`Mapping`](#IMappingObject) of the Field via the [`IContext`](#IContext) provided in construction and the [`IMapper`](#IMapper) that it has, alongside its internal collection that can be added to via the `AddInjectable` method.
+`TinYardInjector` provides the 'injected' value of a Field by finding a [`Mapping`](#IMappingObject) of the Field (with the `mappingName`, if provided) via the [`IMapper`](#IMapper) that it has access to, alongside its internal collection that can be added to via the `AddInjectable` method.
 
 To perform Construction Injection, you need to use one of the `CreateInjected` methods. Internally these methods are identical, the Generic version calls the non-Generic version with `typeof(T)`. The `TinYardInjector` will firstly identify any constructors for the object Type that are marked with the [`Inject` attribute](#Inject-Attribute), if any are found it will attempt to create the object with these constructors as a priority - it then will attempt to create the object by finding the constructor it can provide the most parameters to.
 
@@ -270,6 +276,15 @@ To perform Construction Injection, you need to use one of the `CreateInjected` m
 The `Inject` attribute can be added to any Field or Class Constructor.
 
 The `Inject` attribute acts as a flag to the [`IInjector`](#IInjector) in your [`IContext`](#IContext).
+
+When you add the `Inject` attribute you can also provide an optional `Name` value. This will be used by the `IInjector` to provide the specific `Mapping` with the same `Name` when injecting the value - Be careful with this though. The current implementation of [`TinYardInjector`](#TinYardInjector) will not provide a value if it can't find a `Mapping` with an identical `Name`.
+
+Example of a `Named` `Inject` attribute:
+
+```c-sharp
+[Inject("ExampleFoo")]
+public int FooBar;
+```
 
 In the standard implementation of [`IContext`](#IContext), [`Context`](#Context) -
 When a value is added to an [`IMappingObject`](#IMappingObject), the [`IMapper`](#IMapper) lets the [`IContext`](#IContext) know that the value needs injecting into, which in turn tells its [`IInjector`](#IInjector) to Inject into it.

--- a/TinYard.Tests/TestClasses/TestInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestInjectable.cs
@@ -7,6 +7,9 @@ namespace TinYard_Tests.TestClasses
         [Inject]
         public int Value;
 
+        [Inject("TestIn")]
+        public string NamedInjectable;
+
         public float ConstructedFloat { get; private set; }
 
         public TestInjectable()

--- a/TinYard.Tests/Tests/InjectionAttributeTests.cs
+++ b/TinYard.Tests/Tests/InjectionAttributeTests.cs
@@ -20,9 +20,9 @@ namespace TinYard.Tests
         [TestMethod]
         public void Inject_Attribute_Provides_Fields_To_Inject_Into()
         {
-            var fields = InjectAttribute.GetInjectableFields(typeof(TestInjectable));
+            var infos = InjectAttribute.GetInjectableInformation(typeof(TestInjectable));
 
-            Assert.IsTrue(fields.Count > 0);
+            Assert.IsTrue(infos.Count > 0);
         }
 
         [TestMethod]

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -126,5 +126,23 @@ namespace TinYard.Tests
             Assert.AreNotEqual(constructed.InjectableFloat, expectedFloat);
             Assert.AreEqual(constructed.InjectableDouble, expectedDouble);
         }
+
+        [TestMethod]
+        public void Injector_Injects_Into_Named_Attributes()
+        {
+            string valueToInject = "foobar";
+            _context.Mapper.Map<string>("TestIn").ToValue(valueToInject);
+
+            TestInjectable injectable = new TestInjectable();
+
+            string preInjectValue = injectable.NamedInjectable;
+            _injector.Inject(injectable);
+
+            //Shouldn't be the same as pre-inject
+            Assert.AreNotEqual(preInjectValue, injectable.NamedInjectable);
+
+            //Should be the value we mapped
+            Assert.AreEqual(injectable.NamedInjectable, valueToInject);
+        }
     }
 }

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -72,5 +72,26 @@ namespace TinYard.Tests
 
             Assert.AreEqual(expected, mappingObject.MappedValue);
         }
+
+        [TestMethod]
+        public void Mapping_Can_Be_Given_Name()
+        {
+            _mapper.Map<int>("foobar");
+        }
+
+        [TestMethod]
+        public void Mapper_Provides_Named_Mappings()
+        {
+            string mappingName = "foobar";
+            int expected = 1;
+
+            _mapper.Map<int>(mappingName).ToValue(expected);
+            
+            var mapping = _mapper.GetMapping<int>(mappingName);
+            var mappingValue = _mapper.GetMappingValue<int>(mappingName);
+            
+            Assert.IsNotNull(mapping);
+            Assert.AreEqual(expected, mappingValue);
+        }
     }
 }

--- a/TinYard.Tests/Tests/MappingTests.cs
+++ b/TinYard.Tests/Tests/MappingTests.cs
@@ -93,5 +93,44 @@ namespace TinYard.Tests
             Assert.IsNotNull(mapping);
             Assert.AreEqual(expected, mappingValue);
         }
+
+        [TestMethod]
+        public void Mapper_Provides_Named_Mappings_Over_Normal_Order_Dependent()
+        {
+            string mappingName = "foobar";
+            int expected = 1;
+            int notExpected = 2;
+
+            //Map two to the int type, and see if the mapper prefers the one with the name - Maybe because it's mapped first
+            _mapper.Map<int>(mappingName).ToValue(expected);
+            _mapper.Map<int>().ToValue(notExpected);
+
+            var mapping = _mapper.GetMapping<int>(mappingName);
+            var mappingValue = _mapper.GetMappingValue<int>(mappingName);
+
+            Assert.IsNotNull(mapping);
+            Assert.AreEqual(expected, mappingValue);
+            Assert.AreNotEqual(notExpected, mappingValue);
+        }
+
+        [TestMethod]
+        public void Mapper_Provides_Named_Mappings_Over_Normal_Order_Independent()
+        {
+            string mappingName = "foobar";
+            int expected = 1;
+            int notExpected = 2;
+
+            //Map two to the int type, and see if the mapper prefers the one with the name.
+            //Map the named one second so that this test ensures the order of mapping isn't relevant
+            _mapper.Map<int>().ToValue(notExpected);
+            _mapper.Map<int>(mappingName).ToValue(expected);
+
+            var mapping = _mapper.GetMapping<int>(mappingName);
+            var mappingValue = _mapper.GetMappingValue<int>(mappingName);
+
+            Assert.IsNotNull(mapping);
+            Assert.AreEqual(expected, mappingValue);
+            Assert.AreNotEqual(notExpected, mappingValue);
+        }
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -10,15 +10,22 @@ namespace TinYard.API.Interfaces
         event Action<IMappingObject> OnValueMapped;
         IMappingFactory MappingFactory { get; }
 
-        IMappingObject Map<T>(string mappingName = null);
+        IMappingObject Map<T>();
+        IMappingObject Map<T>(string mappingName);
 
-        IMappingObject GetMapping<T>(string mappingName = null);
+        IMappingObject GetMapping<T>();
+        IMappingObject GetMapping<T>(string mappingName);
 
-        IMappingObject GetMapping(Type type, string mappingName = null);
+        IMappingObject GetMapping(Type type);
+        IMappingObject GetMapping(Type type, string mappingName);
+
         IReadOnlyList<IMappingObject> GetAllMappings();
+        IReadOnlyList<IMappingObject> GetAllNamedMappings();
 
-        T GetMappingValue<T>(string mappingName = null);
+        T GetMappingValue<T>();
+        T GetMappingValue<T>(string mappingName);
 
-        object GetMappingValue(Type type, string mappingName = null);
+        object GetMappingValue(Type type);
+        object GetMappingValue(Type type, string mappingName);
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -10,13 +10,15 @@ namespace TinYard.API.Interfaces
         event Action<IMappingObject> OnValueMapped;
         IMappingFactory MappingFactory { get; }
 
-        IMappingObject Map<T>();
+        IMappingObject Map<T>(string mappingName = null);
 
-        IMappingObject GetMapping<T>();
-        IMappingObject GetMapping(Type type);
+        IMappingObject GetMapping<T>(string mappingName = null);
+
+        IMappingObject GetMapping(Type type, string mappingName = null);
         IReadOnlyList<IMappingObject> GetAllMappings();
 
-        T GetMappingValue<T>();
-        object GetMappingValue(Type type);
+        T GetMappingValue<T>(string mappingName = null);
+
+        object GetMappingValue(Type type, string mappingName = null);
     }
 }

--- a/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
+++ b/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using TinYard.Framework.Impl.VO;
 
 namespace TinYard.Framework.Impl.Attributes
 {
@@ -9,14 +10,33 @@ namespace TinYard.Framework.Impl.Attributes
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Constructor /*| AttributeTargets.Property*/, AllowMultiple = false, Inherited = true)]
     public class InjectAttribute : Attribute
     {
-        public static List<FieldInfo> GetInjectableFields(Type classToInjectInto)
+        #region Constructors and Properties
+
+        public string Name { get { return _name; } }
+        private string _name;
+
+        public InjectAttribute(string name = null)
         {
-            List<FieldInfo> injectables = new List<FieldInfo>();
+            this._name = name;
+        }
+
+        #endregion
+
+
+        #region Helper functions
+
+        public static List<InjectableInformation> GetInjectableInformation(Type classToInjectInto)
+        {
+            List<InjectableInformation> injectables = new List<InjectableInformation>();
             
             foreach(FieldInfo field in classToInjectInto.GetFields())
             {
-                if (field.GetCustomAttributes<InjectAttribute>(true).Count() > 0)
-                    injectables.Add(field);
+                var attribute = field.GetCustomAttributes<InjectAttribute>(true).FirstOrDefault();
+                if (attribute != null)
+                {
+                    InjectableInformation info = new InjectableInformation(attribute, field);
+                    injectables.Add(info);
+                }
             }
 
             return injectables;
@@ -34,5 +54,7 @@ namespace TinYard.Framework.Impl.Attributes
 
             return injectableConstructors;
         }
+
+        #endregion
     }
 }

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -49,7 +49,13 @@ namespace TinYard.Impl.Mappers
             //If we're looking for a specific name, try find it
             if(!string.IsNullOrWhiteSpace(mappingName))
             {
-                value = mappingsOfType.FirstOrDefault(mapping => mapping.Name.Equals(mappingName));
+                value = mappingsOfType.FirstOrDefault(mapping =>
+                {
+                    if (string.IsNullOrWhiteSpace(mapping.Name))
+                        return false;
+
+                    return mapping.Name.Equals(mappingName);
+                });
             }
             else if(mappingsOfType.Count() > 0)
             {

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -42,9 +42,20 @@ namespace TinYard.Impl.Mappers
 
         public IMappingObject GetMapping(Type type, string mappingName = null)
         {
-            var mappingsOfType = _mappingObjects.Where(mapping => mapping.MappedType.IsAssignableFrom(type));
+            List<IMappingObject> mappingsOfType = _mappingObjects.Where(mapping => mapping.MappedType.IsAssignableFrom(type)).ToList();
 
-            var value = mappingsOfType.FirstOrDefault(mapping => mapping.Name.Equals(mappingName));
+            IMappingObject value = null;
+
+            //If we're looking for a specific name, try find it
+            if(!string.IsNullOrWhiteSpace(mappingName))
+            {
+                value = mappingsOfType.FirstOrDefault(mapping => mapping.Name.Equals(mappingName));
+            }
+            else if(mappingsOfType.Count() > 0)
+            {
+                //Else, grab the first one
+                value = mappingsOfType[0];
+            }
 
             return value;
         }

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -22,9 +22,9 @@ namespace TinYard.Impl.Mappers
             _mappingFactory = new MappingValueFactory(this);
         }
 
-        public IMappingObject Map<T>()
+        public IMappingObject Map<T>(string mappingName = null)
         {
-            var mappingObj = new MappingObject(this).Map<T>();
+            var mappingObj = new MappingObject(this).Map<T>(mappingName);
 
             if (OnValueMapped != null)
                 mappingObj.OnValueMapped += ( mapping ) => OnValueMapped.Invoke(mapping);
@@ -33,16 +33,18 @@ namespace TinYard.Impl.Mappers
             return mappingObj;
         }
 
-        public IMappingObject GetMapping<T>()
+        public IMappingObject GetMapping<T>(string mappingName = null)
         {
             Type type = typeof(T);
 
-            return GetMapping(type);
+            return GetMapping(type, mappingName);
         }
 
-        public IMappingObject GetMapping(Type type)
+        public IMappingObject GetMapping(Type type, string mappingName = null)
         {
-            var value = _mappingObjects.FirstOrDefault(mapping => mapping.MappedType.IsAssignableFrom(type));
+            var mappingsOfType = _mappingObjects.Where(mapping => mapping.MappedType.IsAssignableFrom(type));
+
+            var value = mappingsOfType.FirstOrDefault(mapping => mapping.Name.Equals(mappingName));
 
             return value;
         }
@@ -52,15 +54,15 @@ namespace TinYard.Impl.Mappers
             return _mappingObjects.AsReadOnly();
         }
 
-        public T GetMappingValue<T>()
+        public T GetMappingValue<T>(string mappingName = null)
         {
-            var mappedValue = GetMapping<T>()?.MappedValue;
+            var mappedValue = GetMapping<T>(mappingName)?.MappedValue;
             return mappedValue is T ? (T)mappedValue : default(T);
         }
 
-        public object GetMappingValue(Type type)
+        public object GetMappingValue(Type type, string mappingName = null)
         {
-            return GetMapping(type)?.MappedValue;
+            return GetMapping(type, mappingName)?.MappedValue;
         }
     }
 }

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -13,8 +13,11 @@ namespace TinYard.Impl.VO
 
         Action<IMappingObject, Type> BuildDelegate { get; set; }
 
-        IMappingObject Map<T>(string mappingName = null);
-        IMappingObject Map(Type type, string mappingName = null);
+        IMappingObject Map<T>();
+        IMappingObject Map<T>(string mappingName);
+
+        IMappingObject Map(Type type);
+        IMappingObject Map(Type type, string mappingName);
 
         IMappingObject ToValue(object value);
         IMappingObject BuildValue<T>();

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -7,12 +7,14 @@ namespace TinYard.Impl.VO
         Type MappedType { get; }
         object MappedValue { get; }
 
+        string Name { get; }
+
         event Action<IMappingObject> OnValueMapped;
 
         Action<IMappingObject, Type> BuildDelegate { get; set; }
 
-        IMappingObject Map<T>();
-        IMappingObject Map(Type type);
+        IMappingObject Map<T>(string mappingName = null);
+        IMappingObject Map(Type type, string mappingName = null);
 
         IMappingObject ToValue(object value);
         IMappingObject BuildValue<T>();

--- a/TinYard/Framework/Impl/VO/InjectableInformation.cs
+++ b/TinYard/Framework/Impl/VO/InjectableInformation.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Framework.Impl.VO
+{
+    public class InjectableInformation
+    {
+        public InjectAttribute Attribute { get; }
+        public FieldInfo Field { get; }
+
+        public InjectableInformation(InjectAttribute attribute, FieldInfo field)
+        {
+            Attribute = attribute;
+            Field = field;
+        }
+    }
+}

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -31,12 +31,24 @@ namespace TinYard.Impl.VO
             _parentMapper = parentMapper;
         }
 
-        public IMappingObject Map<T>(string mappingName = null)
+        public IMappingObject Map<T>()
+        {
+            return Map(typeof(T));
+        }
+
+        public IMappingObject Map<T>(string mappingName)
         {
             return Map(typeof(T), mappingName);
         }
 
-        public IMappingObject Map(Type type, string mappingName = null)
+        public IMappingObject Map(Type type)
+        {
+            _mappedType = type;
+
+            return this;
+        }
+
+        public IMappingObject Map(Type type, string mappingName)
         {
             _mappedType = type;
             _name = mappingName;

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -11,6 +11,9 @@ namespace TinYard.Impl.VO
         public object MappedValue { get { return _mappedValue; } }
         private object _mappedValue = null;
 
+        public string Name { get { return _name; } }
+        private string _name = null;
+
         public event Action<IMappingObject> OnValueMapped;
 
         public Action<IMappingObject, Type> BuildDelegate { get; set; }
@@ -28,14 +31,15 @@ namespace TinYard.Impl.VO
             _parentMapper = parentMapper;
         }
 
-        public IMappingObject Map<T>()
+        public IMappingObject Map<T>(string mappingName = null)
         {
-            return Map(typeof(T));
+            return Map(typeof(T), mappingName);
         }
 
-        public IMappingObject Map(Type type)
+        public IMappingObject Map(Type type, string mappingName = null)
         {
             _mappedType = type;
+            _name = mappingName;
 
             return this;
         }


### PR DESCRIPTION
You can now name your `Injectable` fields!

Sometimes it can be nice to ask for an injection by name, or when multiple are mapped to the same Type you can specify which one you want by name.

* What is new?
  * `IMappingObject` and `MappingObject` now have a `Name` Property that can be set in the `Map` functions.
  * `Inject` Attribute now has an optional `name` parameter.
  * A new VO called `InjectableInformation` has been created within `Framework.Impl.VO`. This is currently used by the `InjectAttribute` class and the `TinYardInjector`.
* What has changed?
  * The `IMapper` and `ValueMapper` can now take an optional name string parameter in `Map`, `GetMapping` and `GetMappingValue`, which will find any particular mappings with the `name` provided or provide the `IMappingObject` with a name in the `Map` method.
 *  The `TinYardInjector` now will handle `Inject` Attributes that have a `Name` and aim to provide the `Field` with a value that was `Mapped` with that `Name`. 
 * The `InjectAttribute` class had the `GetInjectableFields` method replaced with the `GetInjectableInformation` method that returns a list of the new `InjectableInformation` VO instead - Providing more information.

Related issues?    
Resolves #64 

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes

**Should know about**    
This feature will bring breaking changes to any calls to the `InjectAttribute.GetInjectableFields` method. It has been replaced with the `InjectAttribute.GetInjectableInformation` method that now returns `List<InjectableInformation>`. This change wont affect your behaviour, but it will stop compiling. The `FieldInfo` values are still available, you just need to access the `InjectableInformation.FieldInfo` value now instead.