### PR TITLE
Fix/mediator map extension late mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,12 @@ The job of [`ViewRegister`](#ViewRegister) is to provide a place where all [`Vie
 
 ## Mediator Map Extension
 
+### Notes
+
+TinYard versions `v1.2.0` and below (that have this extension within) may have trouble regarding accessing the `IMediatorMapper` in their `IExtension`s and `IConfig`s.
+
+Original implementation of this `IExtension` added the `IMediatorMapper` to the `Context.IMapper` using the `Context.PostConfigsInstalled` hook and thus require you to access it there too. This is a pain, hence the fix! 
+
 ### Dependencies
 
 This Extension is dependant on:
@@ -535,7 +541,7 @@ The [Mediator Map Extension](#Mediator-Map-Extension) provides:
 
 To install the [Mediator Map Extension](#Mediator-Map-Extension), install the [`MediatorMapExtension`](#Mediator-Map-Extension) class into your [Context](#IContext).
 
-Currently, there are no configurations for the Extension.
+There is an `MediatorMapConfig` class but don't worry about calling `.Configure()` on it as the `MediatorMapExtension` does this itself.
 
 ### IMediator
 
@@ -554,6 +560,7 @@ When the related [`IView`](#IView) property, known as ViewComponent, is set the 
 The base [`Mediator`](#Mediator) class provides methods to add listeners to the [`IView`](#IView), as well as to the [`IContext`](#IContext)'s mapped [`IEventDispatcher`](#IEventDispatcher).
 
 ##### Configure
+
 When creating your own [`Mediator`](#Mediator), you will have to provide a `Configure` method implementation. This is where you should add any listeners, as you will not have a reference to your [`IView`](#IView) in the constructor but this method should be called when a [`IView`](#IView) is provided.
 
 ##### Attached View

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapExtensionTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.API.Interfaces;
 using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.ViewController;
 
 namespace TinYard.Extensions.MediatorMap.Tests
 {
@@ -33,6 +34,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
         [TestMethod]
         public void Context_Installs_Extension()
         {
+            _context.Install(new ViewControllerExtension());
             _context.Install(_extension);
             _context.Initialize();
         }
@@ -47,6 +49,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
 
         private void SetupExtension()
         {
+            _context.Install(new ViewControllerExtension());
             _context.Install(_extension);
             _context.Initialize();
         }

--- a/TinYard/Extensions/MediatorMap/MediatorMapConfig.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapConfig.cs
@@ -1,0 +1,23 @@
+﻿using TinYard.API.Interfaces;
+using TinYard.Extensions.MediatorMap.API.Interfaces;
+using TinYard.Extensions.MediatorMap.Impl.Mappers;
+using TinYard.Extensions.ViewController.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Extensions.MediatorMap
+{
+    public class MediatorMapConfig : IConfig
+    {
+        [Inject]
+        public IContext context;
+
+        [Inject]
+        public IViewRegister viewRegister;
+
+        public void Configure()
+        {
+            MediatorMapper mediatorMapper = new MediatorMapper(context, viewRegister);
+            context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
+        }
+    }
+}

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using TinYard.API.Interfaces;
-using TinYard.Extensions.EventSystem.API.Interfaces;
-using TinYard.Extensions.EventSystem.Impl;
-using TinYard.Extensions.MediatorMap.API.Interfaces;
-using TinYard.Extensions.MediatorMap.Impl.Mappers;
-using TinYard.Extensions.ViewController.API.Interfaces;
-using TinYard.Framework.API.Interfaces;
+﻿using TinYard.API.Interfaces;
 
 namespace TinYard.Extensions.MediatorMap
 {
@@ -17,22 +10,7 @@ namespace TinYard.Extensions.MediatorMap
         {
             _context = context;
 
-            _context.PostConfigsInstalled += OnContextInitialized;
-        }
-
-        private void OnContextInitialized()
-        {
-            IViewRegister viewRegister = _context.Mapper.GetMappingValue<IViewRegister>();
-            IInjector injector = _context.Mapper.GetMappingValue<IInjector>();
-
-            MediatorMapper mediatorMapper = new MediatorMapper(_context);
-            
-            if (viewRegister != null && injector != null)
-            {
-                mediatorMapper = new MediatorMapper(_context, viewRegister);
-            }
-
-            _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
+            _context.Configure(new MediatorMapConfig());
         }
     }
 }


### PR DESCRIPTION
Previously, the `MediatorMapExtension` would `Map` the `IMediatorMap` _after_ the `IConfig`s had been installed.. This is a bitch to work with. It makes setting up any `IConfig` or `IExtension` that depends on it a real pain as you then also have to do the same with yours - Defeating the point of the `PostConfigsInstalled` hook.

`MediatorMapExtension` now `Map`s `IMediatorMap` in an `IConfig` like normal extensions should - You don't need to look for it in the `PostConfigsInstalled` hook.

By extension, `MVCBundle` is much nicer to work with too.

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes

**Should know about**    
Updated documentation to warn about earlier TinYard versions requiring the `PostConfigsInstalled` Hook.