### PR TITLE
Fix/bundles installed late

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,30 +129,29 @@ The [`Context`](#Context), [`Mapper`](#IMapper), and [`Injector`](#IInjector) ar
 
 The [`Context`](#Context) can only be 'Initalized' once - This means you can only call the [`Initalize`](#Initialize) method once, any more calls to it will raise a [Context Exception](#ContextException).
 
-The `Initalize` method has four steps:
-* [Install Bundles](#Install-Bundles)
+The `Initalize` method has three steps:
 * [Install Extensions](#Install-Extensions)
 * [Install Configs](#Install-Configs)
 * [Post Initialize](#Post-Initialize)
 
+A pre-cursor to the `Initialize` method is the [Install Bundles step](#install-bundles).
+
 Each step has two `event` hook that can be subscribed to, one is invoked before the step and the other is invoked afterwards - Except for [Post Initialize](#Post-Initialize).
 
 Hook order:
-1. `PreBundlesInstalled`
-2. `PostBundlesInstalled`
-3. `PreExtensionsInstalled`
-4. `PostExtensionsInstalled`
-5. `PreConfigsInstalled`
-6. `PostConfigsInstalled`
-7. `PostInitialize`
+1. `PreExtensionsInstalled`
+2. `PostExtensionsInstalled`
+3. `PreConfigsInstalled`
+4. `PostConfigsInstalled`
+5. `PostInitialize`
 
 ##### Install Bundles
 
-Install Bundles is the first of the four steps. It runs first, as it has a direct effect on the next two steps.
+Install Bundles is a unique step and so isn't included above. It runs first, as it has a direct effect on the next steps.
 
-[Bundles](#IBundle) should typically be just installing [`IExtension`](#IExtension)'s and [`IConfig`](#IConfig)'s.  
+[Bundles](#IBundle) are installed instantly. When you call the `Install` method on your `Context` and pass it a `Bundle`, it will call the `Install` method instantly on the `Bundle` so that each `Extension` and `Config` within gets added to the `Context` in the correct order.
 
-When an [`IBundle`](#IBundle) is installed via the `Install(IBundle bundle)` method, it is added to a `private List<IBundle> _bundlesToInstall`. When the [`Context`](#Context) goes to install the List of `IBundle`'s it simply calls the `Install` method on each and passes itself to the Bundle, which in form then usually calls `Install(IExtension extension)` and `Configure(IConfig config)` onto the [`Context`](#Context), just making the installation of multiple Extensions and Configs that are together a bit tidier.
+[Bundles](#IBundle) should be just installing [`IExtension`](#IExtension)'s and [`IConfig`](#IConfig)'s, except in unique cases. This is due to the manner in which they are treated as explained above.
 
 So, Bundles are simply just wrappers for installing multiple Extensions and Configs. Because of that, this is why they are installed first - So that the actual extensions and configs installation has the extensions and configs from these bundles in their lists.
 

--- a/TinYard.Tests/TestClasses/DependableTestConfig.cs
+++ b/TinYard.Tests/TestClasses/DependableTestConfig.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TinYard.API.Interfaces;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class DependableTestConfig : IConfig
+    {
+        [Inject]
+        public IContext context;
+
+        public void Configure()
+        {
+            context.Mapper.Map<int>().ToValue(69);
+        }
+    }
+}

--- a/TinYard.Tests/TestClasses/TestBundle.cs
+++ b/TinYard.Tests/TestClasses/TestBundle.cs
@@ -4,11 +4,18 @@ namespace TinYard.Tests.MockClasses
 {
     public class TestBundle : IBundle
     {
+        public readonly bool HaveDependencies;
+
+        public TestBundle(bool haveDependencies = false)
+        {
+            HaveDependencies = haveDependencies;
+        }
+
         public void Install(IContext context)
         {
             context
                 .Install(new TestExtension())
-                .Configure(new TestConfig());
+                .Configure(new TestConfig(HaveDependencies));
         }
     }
 }

--- a/TinYard.Tests/TestClasses/TestConfig.cs
+++ b/TinYard.Tests/TestClasses/TestConfig.cs
@@ -9,9 +9,22 @@ namespace TinYard.Tests.MockClasses
         [Inject]
         public IContext context;
 
+        public readonly bool HaveDependencies;
+
+        public TestConfig(bool haveDependencies = false)
+        {
+            HaveDependencies = haveDependencies;
+        }
+
         public void Configure()
         {
-            
+            if(HaveDependencies)
+            {
+                var val = context.Mapper.GetMappingValue<int>();
+
+                if (val == 0)
+                    throw new ArgumentOutOfRangeException(nameof(val), "Value not mapped.");
+            }
         }
     }
 }

--- a/TinYard.Tests/Tests/ContextTests.cs
+++ b/TinYard.Tests/Tests/ContextTests.cs
@@ -4,6 +4,7 @@ using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Exceptions;
 using TinYard.Tests.MockClasses;
+using TinYard.Tests.TestClasses;
 using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests
@@ -90,6 +91,22 @@ namespace TinYard.Tests
             _context.Initialize();
 
             //Assert nothing, if it doesn't throw it's a success
+        }
+
+        [TestMethod]
+        public void Context_Installs_Bundles_Before_Others()
+        {
+            IBundle testBundle = new TestBundle(true);
+            _context.Install(testBundle);
+            _context.Configure(new DependableTestConfig());
+
+            //This should throw. TestConfig in the bundle is dependant on the DependableTestConfig.
+            //If the bundle was installed _after_ the other config then the value it is after will be available
+            //and the config wont throw an exception
+            Assert.ThrowsException<ArgumentOutOfRangeException>(()=>
+            {
+                _context.Initialize();
+            });
         }
 
         //

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -149,6 +149,12 @@ namespace TinYard
 
         private void InstallBundles()
         {
+            //Get the previous installed extensions and configs out of the way so we can place
+            //the extensions after the bundles
+
+            //REFACTOR : Is there a better way to do this?
+            //Maybe we can use the `PostBundlesInstalled` hook in .Install & .Configure methods
+            //So we don't need to reallocate/move these below
             IExtension[] extensionsToHold = new IExtension[_extensionsToInstall.Count];
             _extensionsToInstall.CopyTo(extensionsToHold);
 

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -149,6 +149,15 @@ namespace TinYard
 
         private void InstallBundles()
         {
+            IExtension[] extensionsToHold = new IExtension[_extensionsToInstall.Count];
+            _extensionsToInstall.CopyTo(extensionsToHold);
+
+            IConfig[] configsToHold = new IConfig[_configsToInstall.Count];
+            _configsToInstall.CopyTo(configsToHold);
+
+            _extensionsToInstall.Clear();
+            _configsToInstall.Clear();
+
             _bundlesInstalled = new HashSet<IBundle>();
             foreach(IBundle bundle in _bundlesToInstall)
             {
@@ -164,6 +173,9 @@ namespace TinYard
             }
 
             _bundlesToInstall.Clear();
+
+            _extensionsToInstall.AddRange(extensionsToHold);
+            _configsToInstall.AddRange(configsToHold);
         }
 
         private void InstallExtensions()


### PR DESCRIPTION
Resolves #87 

Extensions and Configs from Bundles now install in the correct order.

Previously, Bundle extensions and configs would get added to the bottom of the list - after other extensions and configs. Now, they're installed in the correct order and integrity is kept.

I've also added some more tests for bundles within this MR.

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes