### PR TITLE
Feature/mulitple binding injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ TinYard has more advanced features for those who need unlimited power.
 Here's some advanced features:
 
 * [Environments](#Environments)
+* [Inject Multiple](#Inject-Multiple)
 
 ### Environments
 
@@ -103,6 +104,50 @@ For example: You could easily setup two `IConfig`s, one for test and one for pro
 NB: Make sure that if you're using specific Configurations or Extensions based on the `Environment` that you set the `Environment` before calling `Initialize` on your `IContext`.
 
 Tip: If you only need to change the `Config` used based on the `Environment`, you can still use an `IExtension` to load any `Config` file that determines this - Just use the `IContext.PostExtensionsInstalled` or `IContext.PreConfigsInstalled` hook to set the `Environment` after the `IExtension` is installed but before your `IConfig` is.   
+
+
+### Inject Multiple
+
+Sometimes (very rarely most likely!), you are going to want all of the values that can be provided for a certain type injected into your class. This is where the `allowMultiple` override comes into play on the [`Inject`](#inject-attribute) attribute.
+
+This is best explained with an example:
+
+Imagine you have multiple types of 'beverages' that implement an `IBeverage` interface in your application and you have all of these mapped under the `IBeverage` interface with different values - In your `RestockFridgeCommand` you want to know all the types of `IBeverage` mapped, so that you can restock your fridge with them of course!
+
+Here's how you would get hold of these `IBeverage`'s:
+
+```csharp
+public class RestockFridgeCommand : ICommand
+{
+    [Inject(allowMultiple: true)]
+    public IEnumerable<IBeverage> beverages;
+
+    [Inject]
+    public IFridge barFridge;
+
+    public void Execute()
+    {
+        //Iterate each mapped IBeverage to restock the fridge
+        foreach(IBeverage beverage in beverages)
+        {
+            barFridge.Restock(beverage);
+        }
+    } 
+}
+```
+
+Notice what we did? I'll point it out: 
+```csharp
+[Inject(allowMultiple: true)]
+public IEnumerable<IBeverage> beverages;
+```
+
+> NB: Now, this is probably not the best example - Let us know if you come up with a better example. 
+Realistically, the types of `IBeverage` available should probably be coming from a `Model` or `Service` instead that provides information of what's _actually_ available.
+
+When you want to be 'provided' with multiple of a type like above, you should be using an `IEnumerable<T>` of what you want ***and*** `allowMultiple` to be `true`. If this is not the case, it probably will throw an error!
+
+Don't worry though, if `allowMultiple` isn't set to `true` (which is the case by default) you can still be provided with an `IEnumerable` as long as it's mapped as one.
 
 ---
 

--- a/TinYard.Tests/TestClasses/TestCommand.cs
+++ b/TinYard.Tests/TestClasses/TestCommand.cs
@@ -1,7 +1,6 @@
 ﻿using TinYard.Extensions.CommandSystem.API.Interfaces;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Framework.Impl.Attributes;
-using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests.TestClasses
 {

--- a/TinYard.Tests/TestClasses/TestInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestInjectable.cs
@@ -1,6 +1,8 @@
-﻿using TinYard.Framework.Impl.Attributes;
+﻿using System.Collections;
+using System.Collections.Generic;
+using TinYard.Framework.Impl.Attributes;
 
-namespace TinYard_Tests.TestClasses
+namespace TinYard.Tests.TestClasses
 {
     public class TestInjectable
     {
@@ -9,6 +11,9 @@ namespace TinYard_Tests.TestClasses
 
         [Inject("TestIn")]
         public string NamedInjectable;
+
+        [Inject(allowMultiple: true)]
+        public IEnumerable<double> MultipleInjectedDoubles;
 
         public float ConstructedFloat { get; private set; }
 

--- a/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestSecondaryInjectable.cs
@@ -1,6 +1,6 @@
 using TinYard.Framework.Impl.Attributes;
 
-namespace TinYard_Tests.TestClasses
+namespace TinYard.Tests.TestClasses
 {
     public class TestSecondaryInjectable
     {

--- a/TinYard.Tests/TestClasses/TestTertiaryInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestTertiaryInjectable.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using TinYard.Framework.Impl.Attributes;
+
+namespace TinYard.Tests.TestClasses
+{
+    public class TestTertiaryInjectable
+    {
+        [Inject(allowMultiple: true)]
+        public IEnumerable<TestInjectable> Injectables;
+    }
+}

--- a/TinYard.Tests/TestClasses/TestTertiaryInjectable.cs
+++ b/TinYard.Tests/TestClasses/TestTertiaryInjectable.cs
@@ -6,6 +6,9 @@ namespace TinYard.Tests.TestClasses
     public class TestTertiaryInjectable
     {
         [Inject(allowMultiple: true)]
-        public IEnumerable<TestInjectable> Injectables;
+        public IEnumerable<TestInjectable> MultipleInjectables;
+
+        [Inject]
+        public IEnumerable<TestInjectable> NotMultipleInjectables;
     }
 }

--- a/TinYard.Tests/Tests/ContextTests.cs
+++ b/TinYard.Tests/Tests/ContextTests.cs
@@ -5,7 +5,6 @@ using TinYard.Framework.API.Interfaces;
 using TinYard.Impl.Exceptions;
 using TinYard.Tests.MockClasses;
 using TinYard.Tests.TestClasses;
-using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests
 {

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
@@ -6,7 +6,6 @@ using TinYard.Extensions.CommandSystem.Impl.Factories;
 using TinYard.Extensions.EventSystem.Tests.MockClasses;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Tests.TestClasses;
-using TinYard_Tests.TestClasses;
 
 namespace TinYard.Extensions.CommandSystem.Tests
 {

--- a/TinYard.Tests/Tests/InjectionAttributeTests.cs
+++ b/TinYard.Tests/Tests/InjectionAttributeTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TinYard.Framework.Impl.Attributes;
-using TinYard_Tests.TestClasses;
+using TinYard.Tests.TestClasses;
 
 namespace TinYard.Tests
 {

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
 using TinYard.Framework.Impl.Injectors;
-using TinYard_Tests.TestClasses;
+using TinYard.Tests.TestClasses;
 
 namespace TinYard.Tests
 {
@@ -143,6 +144,57 @@ namespace TinYard.Tests
 
             //Should be the value we mapped
             Assert.AreEqual(injectable.NamedInjectable, valueToInject);
+        }
+
+        [TestMethod]
+        public void Injector_Provides_Multiple_Injectables()
+        {
+            double valToInject1 = 3.14d;
+            double valToInject2 = 7.28d;
+            _context.Mapper.Map<double>().ToValue(valToInject1);
+            _context.Mapper.Map<double>().ToValue(valToInject2);
+
+            TestInjectable injectable = new TestInjectable();
+            _injector.Inject(injectable);
+
+            var injectedVals = injectable.MultipleInjectedDoubles;
+
+            Assert.IsTrue(
+                injectedVals.Contains(valToInject1) &&
+                injectedVals.Contains(valToInject2)
+                );
+        }
+
+        [TestMethod]
+        public void Injector_Injects_Into_Multiple_Injectables_List()
+        {
+            double valToInject1 = 3.14d;
+            double valToInject2 = 7.28d;
+            _context.Mapper.Map<double>().ToValue(valToInject1);
+            _context.Mapper.Map<double>().ToValue(valToInject2);
+
+            int valToInject3 = 69;
+            _context.Mapper.Map<int>().ToValue(valToInject3);
+
+            TestInjectable valToInject4 = new TestInjectable();
+            TestInjectable valToInject5 = new TestInjectable();
+            _context.Mapper.Map<TestInjectable>().ToValue(valToInject4);
+            _context.Mapper.Map<TestInjectable>().ToValue(valToInject5);
+
+            TestTertiaryInjectable injectable = new TestTertiaryInjectable();
+            _injector.Inject(injectable);
+
+            var primaryInjectables = injectable.Injectables;
+
+            foreach(TestInjectable primaryInjectable in primaryInjectables)
+            {
+                Assert.IsTrue(
+                    primaryInjectable.MultipleInjectedDoubles.Contains(valToInject1) &&
+                    primaryInjectable.MultipleInjectedDoubles.Contains(valToInject2)
+                    );
+
+                Assert.AreEqual(valToInject3, primaryInjectable.Value);
+            }
         }
     }
 }

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Linq;
 using TinYard.API.Interfaces;
 using TinYard.Framework.API.Interfaces;
@@ -184,7 +185,7 @@ namespace TinYard.Tests
             TestTertiaryInjectable injectable = new TestTertiaryInjectable();
             _injector.Inject(injectable);
 
-            var primaryInjectables = injectable.Injectables;
+            var primaryInjectables = injectable.MultipleInjectables;
 
             foreach(TestInjectable primaryInjectable in primaryInjectables)
             {
@@ -195,6 +196,39 @@ namespace TinYard.Tests
 
                 Assert.AreEqual(valToInject3, primaryInjectable.Value);
             }
+        }
+
+        [TestMethod]
+        public void Injector_Only_Injects_Multiple_When_Requested()
+        {
+            double valToInject1 = 3.14d;
+            double valToInject2 = 7.28d;
+            _context.Mapper.Map<double>().ToValue(valToInject1);
+            _context.Mapper.Map<double>().ToValue(valToInject2);
+
+            int valToInject3 = 69;
+            _context.Mapper.Map<int>().ToValue(valToInject3);
+
+            List<TestInjectable> valToInject4 = new List<TestInjectable>();
+            var mockVal1 = new TestInjectable();
+            var mockVal2 = new TestInjectable();
+            valToInject4.Add(mockVal1);
+            valToInject4.Add(mockVal2);
+
+            TestInjectable valToInject5 = new TestInjectable();
+            TestInjectable valToInject6 = new TestInjectable();
+
+            _context.Mapper.Map<IEnumerable<TestInjectable>>().ToValue(valToInject4);
+            _context.Mapper.Map<TestInjectable>().ToValue(valToInject5);
+            _context.Mapper.Map<TestInjectable>().ToValue(valToInject6);
+
+            TestTertiaryInjectable injectable = new TestTertiaryInjectable();
+            _injector.Inject(injectable);
+
+            var primaryInjectables = injectable.NotMultipleInjectables;
+
+            Assert.IsTrue(primaryInjectables.Contains(mockVal1));
+            Assert.IsTrue(primaryInjectables.Contains(mockVal2));
         }
     }
 }

--- a/TinYard.Tests/Tests/MappingFactoryTests.cs
+++ b/TinYard.Tests/Tests/MappingFactoryTests.cs
@@ -6,7 +6,6 @@ using TinYard.Framework.Impl.Factories;
 using TinYard.Impl.Mappers;
 using TinYard.Impl.VO;
 using TinYard.Tests.TestClasses;
-using TinYard_Tests.TestClasses;
 
 namespace TinYard.Tests
 {

--- a/TinYard/ExtensionMethods/GenericConstructionExtensions.cs
+++ b/TinYard/ExtensionMethods/GenericConstructionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace TinYard.ExtensionMethods
+{
+    //Internal so that this doesn't get included in the build
+    internal static class GenericConstructionExtensions
+    {
+        public static IList CreateList(Type listType)
+        {
+            Type genericListType = typeof(List<>).MakeGenericType(listType);
+            return (IList)Activator.CreateInstance(genericListType);
+        }
+    }
+}

--- a/TinYard/ExtensionMethods/GenericConstructionExtensions.cs
+++ b/TinYard/ExtensionMethods/GenericConstructionExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace TinYard.ExtensionMethods
 {
-    //Internal so that this doesn't get included in the build
+    //Internal so that this doesn't get included for use outside of this dll
     internal static class GenericConstructionExtensions
     {
         public static IList CreateList(Type listType)

--- a/TinYard/Framework/API/Interfaces/IMapper.cs
+++ b/TinYard/Framework/API/Interfaces/IMapper.cs
@@ -27,7 +27,12 @@ namespace TinYard.API.Interfaces
         IMappingObject GetMapping(Type type, string mappingName);
         IMappingObject GetMapping(Type type, object environment, string mappingName);
 
+        IReadOnlyList<IMappingObject> GetAllMappings<T>();
+        IReadOnlyList<IMappingObject> GetAllMappings(Type type);
         IReadOnlyList<IMappingObject> GetAllMappings();
+
+        IReadOnlyList<IMappingObject> GetAllNamedMappings<T>();
+        IReadOnlyList<IMappingObject> GetAllNamedMappings(Type type);
         IReadOnlyList<IMappingObject> GetAllNamedMappings();
 
         T GetMappingValue<T>();

--- a/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
+++ b/TinYard/Framework/Impl/Attributes/InjectAttribute.cs
@@ -15,9 +15,23 @@ namespace TinYard.Framework.Impl.Attributes
         public string Name { get { return _name; } }
         private string _name;
 
-        public InjectAttribute(string name = null)
+        public bool AllowMultiple { get { return _allowMultiple; } }
+        private bool _allowMultiple = false;
+
+        public InjectAttribute(string name) : this(name, false)
+        {
+
+        }
+
+        public InjectAttribute(bool allowMultiple) : this(null, allowMultiple)
+        {
+
+        }
+
+        public InjectAttribute(string name = null, bool allowMultiple = false)
         {
             this._name = name;
+            this._allowMultiple = allowMultiple;
         }
 
         #endregion

--- a/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
+++ b/TinYard/Framework/Impl/Injectors/TinYardInjector.cs
@@ -60,6 +60,7 @@ namespace TinYard.Framework.Impl.Injectors
             }
         }
 
+        //TODO : Look at tidying this up? Feels a bit messy
         public void Inject(object target)
         {
             var injectableInformations = GetInjectableInformation(target);

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -116,16 +116,35 @@ namespace TinYard.Impl.Mappers
             return FilterByType(filteredMappings, type).FirstOrDefault();
         }
 
+        public IReadOnlyList<IMappingObject> GetAllMappings<T>()
+        {
+            return GetAllMappings(typeof(T));
+        }
+
+        public IReadOnlyList<IMappingObject> GetAllMappings(Type type)
+        {
+            return _mappingObjects.Where(mapping => mapping.MappedType == type).ToList().AsReadOnly();
+        }
+
         public IReadOnlyList<IMappingObject> GetAllMappings()
         {
             return _mappingObjects.AsReadOnly();
         }
 
+        public IReadOnlyList<IMappingObject> GetAllNamedMappings<T>()
+        {
+            return GetAllNamedMappings(typeof(T));
+        }
+
+        public IReadOnlyList<IMappingObject> GetAllNamedMappings(Type type)
+        {
+            var mappings = GetAllNamedMappings().Where(mapping => mapping.MappedType == type);
+            return mappings.ToList().AsReadOnly();
+        }
+
         public IReadOnlyList<IMappingObject> GetAllNamedMappings()
         {
-            var mappingObjects = GetAllMappings();
-
-            var namedMappingObjects = mappingObjects.Where(mapping => !string.IsNullOrWhiteSpace(mapping.Name));
+            var namedMappingObjects = _mappingObjects.Where(mapping => !string.IsNullOrWhiteSpace(mapping.Name));
 
             return namedMappingObjects.ToList().AsReadOnly();
         }

--- a/TinYard/Framework/Impl/VO/InjectableInformation.cs
+++ b/TinYard/Framework/Impl/VO/InjectableInformation.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections;
+using System.Reflection;
 using TinYard.Framework.Impl.Attributes;
 
 namespace TinYard.Framework.Impl.VO
@@ -12,6 +14,19 @@ namespace TinYard.Framework.Impl.VO
         {
             Attribute = attribute;
             Field = field;
+        }
+
+        public Type GetFieldValueType()
+        {
+            if(Attribute.AllowMultiple)
+            {
+                //Return the generic used in an IEnumerable
+                return Field.FieldType.GetGenericArguments()[0];
+            }
+            else
+            {
+                return Field.FieldType;
+            }
         }
     }
 }


### PR DESCRIPTION
Add multiple binding injection feature

* What is new?
  * Added injection of multiple values via an `IEnumerable`.
  * Added new namespace - `TinYard.ExtensionMethods` that contains new class: 
      * `GenericConstructionExtensions` with the extension method `CreateList` used to create a list with a runtime type.  
* What was modified?
  * Inject Attribute has a new Property - `bool AllowMultiple` defaulted to false.
  * Inject Attribute has a constructor for each property and a constructor for all properties.
  * Some Test project classes have had their namespaces corrected.
  * `IMapper` interface has more accessibility provided.
     * `ValueMapper` implemented these.
  * `TinYardInjector` has a modified `Inject` method that now handles the edge case of `IEnumerables` and `AllowMultiple` 

Related issues?    
Resolves #65

**Checklist**    
[X] I ran this code locally    
[X] I wrote the necessary tests    
[X] I documented the changes

**Should know about**    
~~This technically could restrict you having an IEnumerable mapped and injected.. this needs thinking about before being merged.~~ This was fixed.
