### PR TITLE
Feature / 78 Injectable lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To get up and running with TinYard all you need is a [`Context`](#Context):
 ```c#
 Context context = new Context();
 
-context.Mapper.Map<IExampleInterface>().ToValue<ExampleImplementation>();
+context.Mapper.Map<IExampleInterface>().ToSingleton<ExampleImplementation>();
 ```
 
 With the snippet above setup, you can [`Inject`](#Inject-Attribute) the `ExampleImplementation` into another class by asking for the `IExampleInterface` in the class like so:
@@ -355,7 +355,7 @@ An example of this is the [`ValueMapper`](#ValueMapper).
 An example of how to use it:
 
 ```c-sharp
-valueMapper.Map<IContext>().ToValue(context);
+valueMapper.Map<IContext>().ToSingleton<IContext>(context);
 ```
 
 This example, means that when we request the Value of [`IContext`](#IContext) from the `valueMapper` object, we receive the `context` object - Whatever that is.
@@ -387,17 +387,17 @@ When `Map<T>()` is called on the `ValueMapper`, it returns the `IMappingObject`.
 
 Internally, `Map<T>()` on the `ValueMapper` calls `Map<T>()` on a newly created `IMappingObject` and then returns this newly created object. This `Map<T>()` method on IMappingObject should set the `MappedType` to the type of `T`.
 
-`MappedValue` is then the value that is set with the `ToValue(object value)` method.
+`MappedValue` is then the value that is set with the `ToSingleton<T>(T value)` method.
 
-The `BuildValue<T>()` function can create the `MappedValue` object of type `T` for you. This should have a default implementation, but you can also modify how this works by setting the `BuildDelegate<IMappingObject, Type>` Action.
+The `ToSingleton<T>()` function can create the `MappedValue` object of type `T` for you. This should have a default implementation, but you can also modify how this works by setting the `BuildDelegate<IMappingObject, Type>` Action.
 
-The `BuildDelegate<IMappingObject, Type>` Action, when invoked, should provide you the `IMappingObject` that is calling it and the type of the generic `T` passed into the `BuildValue<T>` function.
+The `BuildDelegate<IMappingObject, Type>` Action, when invoked, should provide you the `IMappingObject` that is calling it and the type of the generic `T` passed into the `ToSingleton<T>` function.
 
 #### MappingObject
 
 `MappingObject` provides a super-simple implementation of [`IMappingObject`](#IMappingObject) that is used by [`ValueMapper`](#ValueMapper). 
 
-`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when the default `BuildValue<T>` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value unless an override has been provided on the `BuildDelegate<IMappingObject, Type>` Action.
+`MappingObject` optionally has a reference to the `IMapper` that creates it, passed to it via the constructor. This is so that it can use the Factory that the `IMapper` has to build an object when the default `ToSingleton<T>` is called on the `MappingObject`. If no `IMapper` is provided, it will simply not be able to build the value unless an override has been provided on the `BuildDelegate<IMappingObject, Type>` Action.
 
 ### IInjector
 
@@ -463,7 +463,7 @@ The [`MappingValueFactory`](#MappingValueFactory) is used by the [`ValueMapper`]
 
 As all [`IMappingObject`](#IMappingObject)'s have a method that might need a value object to be created, the [`ValueMapper`](#ValueMapper) provides the [`MappingObject`](#MappingObject) with its factory to create that value from.
 
-Internally, the `BuildValue<T>` method uses the [`IInjector`](#IInjector) that is mapped to its parent [`IMapper`](#IMapper) after determining the type required.  
+Internally, the `ToSingleton<T>` method uses the [`IInjector`](#IInjector) that is mapped to its parent [`IMapper`](#IMapper) after determining the type required.  
 
 #### GuardFactory
 

--- a/TinYard.Tests/TestClasses/DependableTestConfig.cs
+++ b/TinYard.Tests/TestClasses/DependableTestConfig.cs
@@ -15,7 +15,7 @@ namespace TinYard.Tests.TestClasses
 
         public void Configure()
         {
-            context.Mapper.Map<int>().ToValue(69);
+            context.Mapper.Map<int>().ToSingleton(69);
         }
     }
 }

--- a/TinYard.Tests/Tests/ContextTests.cs
+++ b/TinYard.Tests/Tests/ContextTests.cs
@@ -169,10 +169,10 @@ namespace TinYard.Tests
             Assert.IsTrue(preInjectValue != testValue);
 
             //Map an int value so that we can test if it's changed later
-            _context.Mapper.Map<int>().ToValue(testValue);
+            _context.Mapper.Map<int>().ToSingleton(testValue);
 
             //Injector should run on this happening
-            _context.Mapper.Map<TestInjectable>().ToValue(testInjectable);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(testInjectable);
 
             int postInjectValue = testInjectable.Value;
 

--- a/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
+++ b/TinYard.Tests/Tests/Extensions/CommandSystem/CommandFactoryTests.cs
@@ -57,7 +57,7 @@ namespace TinYard.Extensions.CommandSystem.Tests
         [TestMethod]
         public void CommandFactory_Injects_Command()
         {
-            _context.Mapper.Map<TestInjectable>().ToValue(new TestInjectable());
+            _context.Mapper.Map<TestInjectable>().ToSingleton(new TestInjectable());
 
             TestEvent tEvent = new TestEvent(TestEvent.Type.Test1);
             var command = _commandFactory.Build<TestCommand>(tEvent);
@@ -70,7 +70,7 @@ namespace TinYard.Extensions.CommandSystem.Tests
         public void CommandFactory_Injects_Command_Correctly()
         {
             var expectedInjectable = new TestInjectable();
-            _context.Mapper.Map<TestInjectable>().ToValue(expectedInjectable);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(expectedInjectable);
 
             TestEvent expectedEvent = new TestEvent(TestEvent.Type.Test1);
             var command = _commandFactory.Build<TestCommand>(expectedEvent);

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorMapperTests.cs
@@ -24,7 +24,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
         {
             _context = new Context();
             _context.Install(new ViewControllerExtension());
-            _context.Mapper.Map<IEventDispatcher>().ToValue(new EventSystem.Impl.EventDispatcher(_context));
+            _context.Mapper.Map<IEventDispatcher>().ToSingleton(new EventSystem.Impl.EventDispatcher(_context));
             _context.Initialize();
             
             _viewRegister = _context.Mapper.GetMappingValue<IViewRegister>();

--- a/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
+++ b/TinYard.Tests/Tests/Extensions/MediatorMap/MediatorTests.cs
@@ -39,7 +39,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
             //Inject a dispatcher into the Test Mediator, normally done by MediatorMapper
             Context context = new Context();
             IEventDispatcher dispatcher = new EventDispatcher();
-            context.Mapper.Map<IEventDispatcher>().ToValue(dispatcher);
+            context.Mapper.Map<IEventDispatcher>().ToSingleton(dispatcher);
             context.Injector.Inject(_mediator);
 
             bool listenerInvoked = false;
@@ -60,7 +60,7 @@ namespace TinYard.Extensions.MediatorMap.Tests
             //Setup ViewRegister and Injector for our mapper
             Context context = new Context();
             IEventDispatcher eventDispatcher = new EventDispatcher(context);
-            context.Mapper.Map<IEventDispatcher>().ToValue(eventDispatcher);
+            context.Mapper.Map<IEventDispatcher>().ToSingleton(eventDispatcher);
 
             TestView testView = new TestView();
 

--- a/TinYard.Tests/Tests/GuardTests.cs
+++ b/TinYard.Tests/Tests/GuardTests.cs
@@ -57,7 +57,7 @@ namespace TinYard.Tests
 
             _commandMap.Map<TestEvent>(TestEvent.Type.Test1).ToCommand<TestGuardedCommand>().WithGuard<TestGuard>();
 
-            _context.Mapper.Map<string>().ToValue("69");
+            _context.Mapper.Map<string>().ToSingleton("69");
 
             _eventDispatcher.Dispatch(new TestEvent(TestEvent.Type.Test1));
 

--- a/TinYard.Tests/Tests/InjectorTests.cs
+++ b/TinYard.Tests/Tests/InjectorTests.cs
@@ -38,7 +38,7 @@ namespace TinYard.Tests
         public void Injector_injects_into_class()
         {
             int valueToInject = 5;
-            _context.Mapper.Map<int>().ToValue(valueToInject);
+            _context.Mapper.Map<int>().ToSingleton(valueToInject);
 
             TestInjectable injectable = new TestInjectable();
 
@@ -88,7 +88,7 @@ namespace TinYard.Tests
         public void Injector_Injects_Into_Injectable_Values()
         {
             TestInjectable injectable = new TestInjectable();
-            _context.Mapper.Map<TestInjectable>().ToValue(injectable);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(injectable);
 
             //Making sure it's not been set somehow by accident
             Assert.AreEqual(default(int), injectable.Value);
@@ -96,7 +96,7 @@ namespace TinYard.Tests
             //Map an int so that when we call `Inject` on a class that needs a `TestInjectable`, 
             //it can Inject this int into the `TestInjectable` value
             int expected = 5;
-            _context.Mapper.Map<int>().ToValue(expected);
+            _context.Mapper.Map<int>().ToSingleton(expected);
 
             _injector.Inject(new TestSecondaryInjectable());
 
@@ -107,7 +107,7 @@ namespace TinYard.Tests
         public void Injector_Can_Create_Injectable_Constructor()
         {
             float expected = 3.14f;
-            _context.Mapper.Map<float>().ToValue(expected);
+            _context.Mapper.Map<float>().ToSingleton(expected);
 
             TestInjectable constructed = _injector.CreateInjected<TestInjectable>();
 
@@ -120,8 +120,8 @@ namespace TinYard.Tests
             float expectedFloat = 3.14f;
             double expectedDouble = 3.147d;
 
-            _context.Mapper.Map<float>().ToValue(expectedFloat);
-            _context.Mapper.Map<double>().ToValue(expectedDouble);
+            _context.Mapper.Map<float>().ToSingleton(expectedFloat);
+            _context.Mapper.Map<double>().ToSingleton(expectedDouble);
 
             TestSecondaryInjectable constructed = _injector.CreateInjected<TestSecondaryInjectable>();
 
@@ -133,7 +133,7 @@ namespace TinYard.Tests
         public void Injector_Injects_Into_Named_Attributes()
         {
             string valueToInject = "foobar";
-            _context.Mapper.Map<string>("TestIn").ToValue(valueToInject);
+            _context.Mapper.Map<string>("TestIn").ToSingleton(valueToInject);
 
             TestInjectable injectable = new TestInjectable();
 
@@ -151,7 +151,7 @@ namespace TinYard.Tests
         public void Injector_Can_Inject_Into_Property()
         {
             double expected = 69d;
-            _context.Mapper.Map<double>().ToValue(expected);
+            _context.Mapper.Map<double>().ToSingleton(expected);
 
             TestInjectable injectable = new TestInjectable();
 
@@ -164,7 +164,7 @@ namespace TinYard.Tests
         public void Injector_Can_Inject_Into_Private_Set_Property()
         {
             double expected = 69d;
-            _context.Mapper.Map<double>().ToValue(expected);
+            _context.Mapper.Map<double>().ToSingleton(expected);
 
             TestInjectable injectable = new TestInjectable();
 
@@ -202,8 +202,8 @@ namespace TinYard.Tests
         {
             double valToInject1 = 3.14d;
             double valToInject2 = 7.28d;
-            _context.Mapper.Map<double>().ToValue(valToInject1);
-            _context.Mapper.Map<double>().ToValue(valToInject2);
+            _context.Mapper.Map<double>().ToSingleton(valToInject1);
+            _context.Mapper.Map<double>().ToSingleton(valToInject2);
 
             TestInjectable injectable = new TestInjectable();
             _injector.Inject(injectable);
@@ -221,16 +221,16 @@ namespace TinYard.Tests
         {
             double valToInject1 = 3.14d;
             double valToInject2 = 7.28d;
-            _context.Mapper.Map<double>().ToValue(valToInject1);
-            _context.Mapper.Map<double>().ToValue(valToInject2);
+            _context.Mapper.Map<double>().ToSingleton(valToInject1);
+            _context.Mapper.Map<double>().ToSingleton(valToInject2);
 
             int valToInject3 = 69;
-            _context.Mapper.Map<int>().ToValue(valToInject3);
+            _context.Mapper.Map<int>().ToSingleton(valToInject3);
 
             TestInjectable valToInject4 = new TestInjectable();
             TestInjectable valToInject5 = new TestInjectable();
-            _context.Mapper.Map<TestInjectable>().ToValue(valToInject4);
-            _context.Mapper.Map<TestInjectable>().ToValue(valToInject5);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(valToInject4);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(valToInject5);
 
             TestTertiaryInjectable injectable = new TestTertiaryInjectable();
             _injector.Inject(injectable);
@@ -253,11 +253,11 @@ namespace TinYard.Tests
         {
             double valToInject1 = 3.14d;
             double valToInject2 = 7.28d;
-            _context.Mapper.Map<double>().ToValue(valToInject1);
-            _context.Mapper.Map<double>().ToValue(valToInject2);
+            _context.Mapper.Map<double>().ToSingleton(valToInject1);
+            _context.Mapper.Map<double>().ToSingleton(valToInject2);
 
             int valToInject3 = 69;
-            _context.Mapper.Map<int>().ToValue(valToInject3);
+            _context.Mapper.Map<int>().ToSingleton(valToInject3);
 
             List<TestInjectable> valToInject4 = new List<TestInjectable>();
             var mockVal1 = new TestInjectable();
@@ -268,9 +268,9 @@ namespace TinYard.Tests
             TestInjectable valToInject5 = new TestInjectable();
             TestInjectable valToInject6 = new TestInjectable();
 
-            _context.Mapper.Map<IEnumerable<TestInjectable>>().ToValue(valToInject4);
-            _context.Mapper.Map<TestInjectable>().ToValue(valToInject5);
-            _context.Mapper.Map<TestInjectable>().ToValue(valToInject6);
+            _context.Mapper.Map<IEnumerable<TestInjectable>>().ToSingleton(valToInject4);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(valToInject5);
+            _context.Mapper.Map<TestInjectable>().ToSingleton(valToInject6);
 
             TestTertiaryInjectable injectable = new TestTertiaryInjectable();
             _injector.Inject(injectable);

--- a/TinYard.Tests/Tests/MappingFactoryTests.cs
+++ b/TinYard.Tests/Tests/MappingFactoryTests.cs
@@ -25,7 +25,7 @@ namespace TinYard.Tests
             _mapper = _context.Mapper;
             _mappingFactory = new MappingValueFactory(_mapper);
 
-            _testingMappingObject = _mapper.Map<TestCreatable>().BuildValue<TestCreatable>();
+            _testingMappingObject = _mapper.Map<TestCreatable>().ToSingleton<TestCreatable>();
         }
 
         [TestCleanup]
@@ -50,7 +50,7 @@ namespace TinYard.Tests
         {
             Type expected = typeof(TestCreatable);
 
-            object value = _mappingFactory.Build(_testingMappingObject).MappedValue;
+            var value = _mappingFactory.Build<TestCreatable>();
             Assert.IsInstanceOfType(value, expected);
         }
 
@@ -61,7 +61,7 @@ namespace TinYard.Tests
 
             //Context will be mapped to IContext in Mapper that the Factory is using. 
             //TestCreatable has an IContext dependency in constructor
-            TestCreatable mappedValue = (TestCreatable)_mappingFactory.Build(_testingMappingObject).MappedValue;
+            TestCreatable mappedValue = _mappingFactory.Build<TestCreatable>();
             object actual = mappedValue.Context;
 
             Assert.AreSame(expected, actual);

--- a/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
+++ b/TinYard/Extensions/CallbackTimer/CallbackTimerExtension.cs
@@ -22,7 +22,7 @@ namespace TinYard.Extensions.CallbackTimer
             var callbackTimerService = new CallbackTimerService();
             callbackTimerService.Startup();
 
-            context.Mapper.Map<ICallbackTimer>().ToValue(callbackTimerService);
+            context.Mapper.Map<ICallbackTimer>().ToSingleton(callbackTimerService);
 
             ICommandMap commandMap = context.Mapper.GetMappingValue<ICommandMap>();
 

--- a/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
+++ b/TinYard/Extensions/CommandSystem/CommandSystemExtension.cs
@@ -31,7 +31,7 @@ namespace TinYard.Extensions.CommandSystem
             var injector = _context.Injector;
 
             EventCommandMap commandMap = new EventCommandMap(eventDispatcher, injector);
-            _context.Mapper.Map<ICommandMap>().ToValue(commandMap);
+            _context.Mapper.Map<ICommandMap>().ToSingleton(commandMap);
         }
     }
 }

--- a/TinYard/Extensions/EventSystem/EventSystemExtension.cs
+++ b/TinYard/Extensions/EventSystem/EventSystemExtension.cs
@@ -23,7 +23,7 @@ namespace TinYard.Extensions.EventSystem
             _context = context;
             _eventDispatcher = new EventDispatcher(context);
 
-            _context.Mapper.Map<IEventDispatcher>().ToValue(_eventDispatcher);
+            _context.Mapper.Map<IEventDispatcher>().ToSingleton(_eventDispatcher);
         }
     }
 }

--- a/TinYard/Extensions/Logging/API/Configs/ConsoleLoggingConfig.cs
+++ b/TinYard/Extensions/Logging/API/Configs/ConsoleLoggingConfig.cs
@@ -21,7 +21,7 @@ namespace TinYard.Extensions.Logging.API.Configs
         public void Configure()
         {
             ConsoleLogger consoleLogger = new ConsoleLogger();
-            mapper.Map<ILogger>().ToValue(consoleLogger);
+            mapper.Map<ILogger>().ToSingleton(consoleLogger);
         }
     }
 }

--- a/TinYard/Extensions/Logging/API/Configs/FileLoggingConfig.cs
+++ b/TinYard/Extensions/Logging/API/Configs/FileLoggingConfig.cs
@@ -38,7 +38,7 @@ namespace TinYard.Extensions.Logging.API.Configs
 
             _fileLogger = new FileLogger(_fileDestination, _fileNamePrefix, _maxLogPerFile);
 
-            _context.Mapper.Map<ILogger>().ToValue(_fileLogger);
+            _context.Mapper.Map<ILogger>().ToSingleton(_fileLogger);
         }
 
         public FileLoggingConfig WithFileDestination(string destination)

--- a/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
+++ b/TinYard/Extensions/MediatorMap/MediatorMapExtension.cs
@@ -24,7 +24,7 @@ namespace TinYard.Extensions.MediatorMap
             var viewRegister = _context.Mapper.GetMappingValue<IViewRegister>();
 
             MediatorMapper mediatorMapper = new MediatorMapper(context, viewRegister);
-            _context.Mapper.Map<IMediatorMapper>().ToValue(mediatorMapper);
+            _context.Mapper.Map<IMediatorMapper>().ToSingleton(mediatorMapper);
         }
     }
 }

--- a/TinYard/Extensions/ViewController/ViewControllerExtension.cs
+++ b/TinYard/Extensions/ViewController/ViewControllerExtension.cs
@@ -18,7 +18,7 @@ namespace TinYard.Extensions.ViewController
         {
             ViewRegister viewRegister = new ViewRegister(context);
 
-            context.Mapper.Map<IViewRegister>().ToValue(viewRegister);
+            context.Mapper.Map<IViewRegister>().ToSingleton(viewRegister);
         }
     }
 }

--- a/TinYard/Framework/API/Interfaces/IMappingFactory.cs
+++ b/TinYard/Framework/API/Interfaces/IMappingFactory.cs
@@ -1,9 +1,11 @@
-﻿using TinYard.Impl.VO;
+﻿using System;
+using TinYard.Impl.VO;
 
 namespace TinYard.Framework.API.Interfaces
 {
     public interface IMappingFactory : IFactory
     {
-        IMappingObject Build(IMappingObject mappingObject);
+        T Build<T>() where T : class;
+        object Build(Type valueType);
     }
 }

--- a/TinYard/Framework/Impl/Context.cs
+++ b/TinYard/Framework/Impl/Context.cs
@@ -59,12 +59,12 @@ namespace TinYard
             _injector = new TinYardInjector(this, _mapper);
 
             //Ensure the context, mapper and injector are mapped for injection needs
-            _mapper.Map<IContext>().ToValue(this);
-            _mapper.Map<IMapper>().ToValue(_mapper);
-            _mapper.Map<IInjector>().ToValue(_injector);
+            _mapper.Map<IContext>().ToSingleton(this);
+            _mapper.Map<IMapper>().ToSingleton(_mapper);
+            _mapper.Map<IInjector>().ToSingleton(_injector);
 
 
-            _mapper.Map<IGuardFactory>().ToValue(new GuardFactory());
+            _mapper.Map<IGuardFactory>().ToSingleton(new GuardFactory());
         }
 
         public IContext Install(IExtension extension)

--- a/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
+++ b/TinYard/Framework/Impl/Factories/MappingValueFactory.cs
@@ -26,25 +26,26 @@ namespace TinYard.Framework.Impl.Factories
                 {
                     builtObjects.Add(Build(argument as IMappingObject));
                 }
+                else if(argument is Type)
+                {
+                    builtObjects.Add(Build(argument as Type));
+                }
             }
 
             return builtObjects.ToArray();
         }
 
-        public IMappingObject Build(IMappingObject mappingObject)
+        public T Build<T>() where T : class
         {
-            Type type = mappingObject.MappedValue as Type;
+            return Build(typeof(T)) as T;
+        }
 
-            //In the odd case that the factory is being used when an actual value is already set, we'll get its type
-            if (type == null)
-                type = mappingObject.MappedValue.GetType();
+        public object Build(Type valueType)
+        {
+            if (valueType == null)
+                return null;
 
-            //Last resort, hope it's not an interface
-            if (type == null)
-                type = mappingObject.MappedType;
-
-            object value = _mapper.GetMappingValue<IInjector>().CreateInjected(type);
-            return mappingObject.ToValue(value);
+            return _mapper.GetMappingValue<IInjector>().CreateInjected(valueType);
         }
     }
 }

--- a/TinYard/Framework/Impl/Mappers/ValueMapper.cs
+++ b/TinYard/Framework/Impl/Mappers/ValueMapper.cs
@@ -179,22 +179,26 @@ namespace TinYard.Impl.Mappers
 
         public object GetMappingValue(Type type)
         {
-            return GetMapping(type)?.MappedValue;
+            return GetMappingValue(type, null, null);
         }
 
         public object GetMappingValue(Type type, object environment)
         {
-            return GetMapping(type, environment)?.MappedValue;
+            return GetMappingValue(type, environment, null);
         }
 
         public object GetMappingValue(Type type, string mappingName)
         {
-            return GetMapping(type, mappingName)?.MappedValue;
+            return GetMappingValue(type, null, mappingName);
         }
 
         public object GetMappingValue(Type type, object environment, string mappingName)
         {
-            return GetMapping(type, environment, mappingName)?.MappedValue;
+            var mapping = GetMapping(type, environment, mappingName);
+            if( mapping == null )
+                return null;
+
+            return mapping.MappedValue ?? mapping.BuildDelegate.Invoke(mapping.MappedType);
         }
 
         private IEnumerable<IMappingObject> FilterByEnvironment(IEnumerable<IMappingObject> setToFilter, object filterEnvironment)

--- a/TinYard/Framework/Impl/VO/IMappingObject.cs
+++ b/TinYard/Framework/Impl/VO/IMappingObject.cs
@@ -8,12 +8,11 @@ namespace TinYard.Impl.VO
         object MappedValue { get; }
 
         string Name { get; }
-
         object Environment { get; }
 
         event Action<IMappingObject> OnValueMapped;
 
-        Action<IMappingObject, Type> BuildDelegate { get; set; }
+        Func<Type, object> BuildDelegate { get; set; }
 
         IMappingObject Map<T>();
         IMappingObject Map<T>(string mappingName);
@@ -21,7 +20,8 @@ namespace TinYard.Impl.VO
         IMappingObject Map(Type type);
         IMappingObject Map(Type type, string mappingName);
 
-        IMappingObject ToValue(object value);
-        IMappingObject BuildValue<T>();
+        IMappingObject ToSingleton<T>(T value);
+
+        IMappingObject ToSingleton<T>();
     }
 }

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -9,7 +9,7 @@ namespace TinYard.Impl.VO
         private Type _mappedType = null;
      
         /// <summary>
-        /// Do not use this. Only an implementer of `IMapper` should be touching this.
+        /// Do not use this unless you have very good reason. Only an implementer of `IMapper` should be touching this.
         /// </summary>
         public object MappedValue { get { return _mappedValue; } }
         private object _mappedValue = null;

--- a/TinYard/Framework/Impl/VO/MappingObject.cs
+++ b/TinYard/Framework/Impl/VO/MappingObject.cs
@@ -8,10 +8,11 @@ namespace TinYard.Impl.VO
         public Type MappedType { get { return _mappedType; } }
         private Type _mappedType = null;
      
+        /// <summary>
+        /// Do not use this. Only an implementer of `IMapper` should be touching this.
+        /// </summary>
         public object MappedValue { get { return _mappedValue; } }
         private object _mappedValue = null;
-
-        public bool IsMapped { get; private set; }
 
         public string Name { get { return _name; } }
         private string _name = null;


### PR DESCRIPTION
A change to how you map objects. Previously there was only really one way to map objects, and that was `ToValue` and `BuildValue` which were almost identical except one used a factory for you.

This PR gets rid of `ToValue` and `BuildValue` and essentially renames these both to `ToSingleton`. The idea behind this is that you will always get given the same instance/same ref of the mapped object.
 
This PR also modifies the default behaviour behind the `GetMappingValue` function on the `IMapper`. If on the `IMappingObject` there is no value (which is set by `ToSingleton` methods) then it shall create a new instance of the mapped type every time `GetMappingValue` is invoked against this mapping. E.g, two different injections of a `MappableObject` will provide two different instances/references that are unique to that injection.

* What is new?
  * Added `ToSingleton<T>(T value)` and `ToSingleton<T>()` functions to `IMappingObject`.
* What has changed?
  * Removed `ToValue` and `BuildValue` on `IMappingObject`
  * Default behaviour of `ValueMapper.GetMappingValue`now returns a unique instance of the value if no value is set on the object (and does not set the value on the object as before!).
  * Most, potentially all, extensions needed an update to use the modified `IMappingObject.AsSingleton` method.

Related issues?    
Resolves #78 

**Checklist**    
[x] I ran this code locally    
[x] I wrote the necessary tests    
[x] I documented the changes

**Should know about**
This is a breaking change on `IMappingObject`.
It might be better / needed in the future to add a new Property to `IMappingObject` as with this change, you cannot simply map an interface and call `GetMappingValue` on an `IMappingObject` with the default `ValueMapper`.